### PR TITLE
Add editorKey to FleatherEditor and FleatherField

### DIFF
--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -202,9 +202,12 @@ class FleatherEditor extends StatefulWidget {
   /// Material [ListTile]s.
   final LinkActionPickerDelegate linkActionPickerDelegate;
 
+  final GlobalKey<EditorState>? editorKey;
+
   const FleatherEditor({
     Key? key,
     required this.controller,
+    this.editorKey,
     this.focusNode,
     this.scrollController,
     this.scrollable = true,
@@ -231,10 +234,13 @@ class FleatherEditor extends StatefulWidget {
 
 class _FleatherEditorState extends State<FleatherEditor>
     implements EditorTextSelectionGestureDetectorBuilderDelegate {
-  final GlobalKey<EditorState> _editorKey = GlobalKey<EditorState>();
+  GlobalKey<EditorState>? _editorKey;
+
+  GlobalKey<EditorState> get _effectiveEditorKey =>
+      widget.editorKey ?? _editorKey!;
 
   @override
-  GlobalKey<EditorState> get editableTextKey => _editorKey;
+  GlobalKey<EditorState> get editableTextKey => _effectiveEditorKey;
 
   // TODO: Add support for forcePress on iOS.
   @override
@@ -247,12 +253,25 @@ class _FleatherEditorState extends State<FleatherEditor>
       _selectionGestureDetectorBuilder;
 
   void _requestKeyboard() {
-    _editorKey.currentState?.requestKeyboard();
+    _effectiveEditorKey.currentState?.requestKeyboard();
+  }
+
+  @override
+  void didUpdateWidget(covariant FleatherEditor oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.editorKey != null && widget.editorKey == null) {
+      _editorKey = GlobalKey<EditorState>();
+    } else if (widget.editorKey != null) {
+      _editorKey = null;
+    }
   }
 
   @override
   void initState() {
     super.initState();
+    if (widget.editorKey == null) {
+      _editorKey = GlobalKey<EditorState>();
+    }
     _selectionGestureDetectorBuilder =
         _FleatherEditorSelectionGestureDetectorBuilder(state: this);
   }
@@ -306,7 +325,7 @@ class _FleatherEditorState extends State<FleatherEditor>
     }
 
     Widget child = RawEditor(
-      key: _editorKey,
+      key: _effectiveEditorKey,
       controller: widget.controller,
       focusNode: widget.focusNode,
       scrollController: widget.scrollController,

--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -236,11 +236,8 @@ class _FleatherEditorState extends State<FleatherEditor>
     implements EditorTextSelectionGestureDetectorBuilderDelegate {
   GlobalKey<EditorState>? _editorKey;
 
-  GlobalKey<EditorState> get _effectiveEditorKey =>
-      widget.editorKey ?? _editorKey!;
-
   @override
-  GlobalKey<EditorState> get editableTextKey => _effectiveEditorKey;
+  GlobalKey<EditorState> get editableTextKey => widget.editorKey ?? _editorKey!;
 
   // TODO: Add support for forcePress on iOS.
   @override
@@ -252,9 +249,7 @@ class _FleatherEditorState extends State<FleatherEditor>
   late EditorTextSelectionGestureDetectorBuilder
       _selectionGestureDetectorBuilder;
 
-  void _requestKeyboard() {
-    _effectiveEditorKey.currentState?.requestKeyboard();
-  }
+  void _requestKeyboard() => editableTextKey.currentState?.requestKeyboard();
 
   @override
   void didUpdateWidget(covariant FleatherEditor oldWidget) {
@@ -325,7 +320,7 @@ class _FleatherEditorState extends State<FleatherEditor>
     }
 
     Widget child = RawEditor(
-      key: _effectiveEditorKey,
+      key: editableTextKey,
       controller: widget.controller,
       focusNode: widget.focusNode,
       scrollController: widget.scrollController,

--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -229,7 +229,7 @@ class FleatherEditor extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  _FleatherEditorState createState() => _FleatherEditorState();
+  State<FleatherEditor> createState() => _FleatherEditorState();
 }
 
 class _FleatherEditorState extends State<FleatherEditor>

--- a/packages/fleather/lib/src/widgets/field.dart
+++ b/packages/fleather/lib/src/widgets/field.dart
@@ -138,9 +138,12 @@ class FleatherField extends StatefulWidget {
   /// Defaults to [defaultFleatherEmbedBuilder].
   final FleatherEmbedBuilder embedBuilder;
 
+  final GlobalKey<EditorState>? editorKey;
+
   const FleatherField({
     Key? key,
     required this.controller,
+    this.editorKey,
     this.focusNode,
     this.scrollController,
     this.scrollable = true,
@@ -162,7 +165,7 @@ class FleatherField extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  _FleatherFieldState createState() => _FleatherFieldState();
+  State<FleatherField> createState() => _FleatherFieldState();
 }
 
 class _FleatherFieldState extends State<FleatherField> {
@@ -195,6 +198,7 @@ class _FleatherFieldState extends State<FleatherField> {
   Widget build(BuildContext context) {
     Widget child = FleatherEditor(
       controller: widget.controller,
+      editorKey: widget.editorKey,
       focusNode: widget.focusNode,
       scrollController: widget.scrollController,
       scrollable: widget.scrollable,


### PR DESCRIPTION
This PR adds `editorKey` to `FleatherEditor` and `FleatherField`'s constructor parameters which is then used as `RawEditor`'s key.

Objective:
This change opens up a lot of possibility for developers to develop third-party packages based on Fleather.
But for now I have two things in mind:
1. My [old mention PR](https://github.com/memspace/zefyr/pull/594) on Zefyr can be turned into a standalone package to cooperate with Fleather and display popup in the proper position using `renderEditor` from `EditorState`.
2. We can develop Medium like editing toolbar as a standalone package again using `renderEditor` from `EditorState`.