### PR TITLE
[Fleather] Support for background color

### DIFF
--- a/packages/fleather/lib/src/widgets/text_line.dart
+++ b/packages/fleather/lib/src/widgets/text_line.dart
@@ -301,6 +301,13 @@ class _TextLineState extends State<TextLine> {
       result = _mergeTextStyleWithDecoration(
           result, theme.inlineCode.styleFor(lineStyle));
     }
+    if (nodeStyle.contains(ParchmentAttribute.backgroundColor)) {
+      final value = nodeStyle.value(ParchmentAttribute.backgroundColor);
+      if (value != null) {
+        result = _mergeTextStyleWithDecoration(
+            result, TextStyle(backgroundColor: Color(value)));
+      }
+    }
     return result;
   }
 


### PR DESCRIPTION
This is the first part of a couple of PRs (the first [one](https://github.com/fleather-editor/fleather/pull/21) is related to Parchment)
Simply adapts the text style with the appropriate background color.

***NB**: this won't build successfully as it has a dependency on Parchment*
***NB**: no toolbar item to pick a color in the PR, this will be part of a later PR*