### PR TITLE
Cannot make toolbar appear on empty document (immediately after gaining focus)

### DIFF
--- a/packages/fleather/lib/src/rendering/editor.dart
+++ b/packages/fleather/lib/src/rendering/editor.dart
@@ -240,6 +240,7 @@ class RenderEditor extends RenderEditableContainerBox
   }
 
   double? _maxContentWidth;
+
   set maxContentWidth(double? value) {
     if (_maxContentWidth == value) return;
     _maxContentWidth = value;
@@ -606,10 +607,7 @@ class RenderEditor extends RenderEditableContainerBox
     // components, so always send those events, even if we didn't think it
     // changed. Also, the user long pressing should always send a selection change
     // as well.
-    if (selectionChanged ||
-        (cause == SelectionChangedCause.longPress ||
-            cause == SelectionChangedCause.keyboard ||
-            cause == SelectionChangedCause.doubleTap)) {
+    if (selectionChanged || cause.forcesSelectionChanged) {
       onSelectionChanged?.call(nextSelection, cause);
     }
   }
@@ -1020,4 +1018,11 @@ class FleatherVerticalCaretMovementRun
     _currentTextPosition = _editor.getTextPositionAbove(_currentTextPosition);
     return true;
   }
+}
+
+extension on SelectionChangedCause {
+  bool get forcesSelectionChanged =>
+      this == SelectionChangedCause.longPress ||
+      this == SelectionChangedCause.keyboard ||
+      this == SelectionChangedCause.doubleTap;
 }

--- a/packages/fleather/lib/src/rendering/editor.dart
+++ b/packages/fleather/lib/src/rendering/editor.dart
@@ -601,20 +601,15 @@ class RenderEditor extends RenderEditableContainerBox
     TextSelection nextSelection,
     SelectionChangedCause cause,
   ) {
+    final bool selectionChanged = selection != nextSelection;
     // Changes made by the keyboard can sometimes be "out of band" for listening
     // components, so always send those events, even if we didn't think it
-    // changed. Also, focusing an empty field is sent as a selection change even
-    // if the selection offset didn't change.
-    final focusingEmpty = nextSelection.baseOffset == 0 &&
-        nextSelection.extentOffset == 0 &&
-        !hasFocus;
-    if (nextSelection == selection &&
-        cause != SelectionChangedCause.keyboard &&
-        !focusingEmpty) {
-      return;
-    }
-    if (onSelectionChanged != null) {
-      onSelectionChanged!(nextSelection, cause);
+    // changed. Also, the user long pressing should always send a selection change
+    // as well.
+    if (selectionChanged ||
+        (cause == SelectionChangedCause.longPress ||
+            cause == SelectionChangedCause.keyboard)) {
+      onSelectionChanged?.call(nextSelection, cause);
     }
   }
 

--- a/packages/fleather/lib/src/rendering/editor.dart
+++ b/packages/fleather/lib/src/rendering/editor.dart
@@ -608,7 +608,8 @@ class RenderEditor extends RenderEditableContainerBox
     // as well.
     if (selectionChanged ||
         (cause == SelectionChangedCause.longPress ||
-            cause == SelectionChangedCause.keyboard)) {
+            cause == SelectionChangedCause.keyboard ||
+            cause == SelectionChangedCause.doubleTap)) {
       onSelectionChanged?.call(nextSelection, cause);
     }
   }

--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -26,9 +26,6 @@ import 'text_line.dart';
 import 'text_selection.dart';
 import 'theme.dart';
 
-// TODO: add test - paste on empty document (should not crash on assert)
-// TODO: add test - Show toolbar of empty document upon longPress just after gaining focus
-
 /// Builder function for embeddable objects in [FleatherEditor].
 typedef FleatherEmbedBuilder = Widget Function(
     BuildContext context, EmbedNode node);

--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -26,6 +26,9 @@ import 'text_line.dart';
 import 'text_selection.dart';
 import 'theme.dart';
 
+// TODO: add test - paste on empty document (should not crash on assert)
+// TODO: add test - Show toolbar of empty document upon longPress just after gaining focus
+
 /// Builder function for embeddable objects in [FleatherEditor].
 typedef FleatherEmbedBuilder = Widget Function(
     BuildContext context, EmbedNode node);
@@ -901,7 +904,11 @@ class RawEditorState extends EditorState
     _replaceText(
         ReplaceTextIntent(textEditingValue, data.text!, selection, cause));
     if (cause == SelectionChangedCause.toolbar) {
-      bringIntoView(textEditingValue.selection.extent);
+      SchedulerBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          bringIntoView(textEditingValue.selection.extent);
+        }
+      });
       hideToolbar();
     }
   }

--- a/packages/fleather/lib/src/widgets/text_selection.dart
+++ b/packages/fleather/lib/src/widgets/text_selection.dart
@@ -850,7 +850,7 @@ class EditorTextSelectionGestureDetectorBuilder {
   @protected
   void onDoubleTapDown(TapDownDetails details) {
     if (delegate.selectionEnabled) {
-      renderEditor!.selectWord(cause: SelectionChangedCause.tap);
+      renderEditor!.selectWord(cause: SelectionChangedCause.doubleTap);
       if (shouldShowSelectionToolbar) editor!.showToolbar();
     }
   }


### PR DESCRIPTION
Fixes #29 

-------

Before fix (go to menu once document is open, emulates opening an empty document and setting focus)

https://user-images.githubusercontent.com/17318211/186650849-74b992b9-dea5-419a-bbe9-e3778ada3ddc.mov

After fix

https://user-images.githubusercontent.com/17318211/186650873-f787b8a9-3a67-4c4d-b504-e238fc7f669d.mov


