### PR TITLE
Fix new line after inline embed insertion

### DIFF
--- a/packages/parchment/lib/src/heuristics.dart
+++ b/packages/parchment/lib/src/heuristics.dart
@@ -26,8 +26,8 @@ class ParchmentHeuristics {
     ],
     insertRules: [
       // Embeds
-      InsertEmbedsRule(),
-      ForceNewlineForInsertsAroundEmbedRule(),
+      InsertBlockEmbedsRule(),
+      ForceNewlineForInsertsAroundBlockEmbedRule(),
       // Blocks
       AutoExitBlockRule(), // must go first
       PreserveBlockStyleOnInsertRule(),

--- a/packages/parchment/lib/src/heuristics/insert_rules.dart
+++ b/packages/parchment/lib/src/heuristics/insert_rules.dart
@@ -448,7 +448,7 @@ class InsertEmbedsRule extends InsertRule {
   @override
   Delta? apply(Delta document, int index, Object data) {
     // We are only interested in embeddable objects.
-    if (data is String) return null;
+    if (data is String || !isBlockEmbed(data)) return null;
 
     final result = Delta()..retain(index);
     final iter = DeltaIterator(document);

--- a/packages/parchment/lib/src/heuristics/insert_rules.dart
+++ b/packages/parchment/lib/src/heuristics/insert_rules.dart
@@ -324,8 +324,8 @@ class AutoFormatLinksRule extends InsertRule {
 /// to be moved to a new line adjacent to the original line.
 ///
 /// This rule assumes that a line is only allowed to have single block embed child.
-class ForceNewlineForInsertsAroundEmbedRule extends InsertRule {
-  const ForceNewlineForInsertsAroundEmbedRule();
+class ForceNewlineForInsertsAroundBlockEmbedRule extends InsertRule {
+  const ForceNewlineForInsertsAroundBlockEmbedRule();
 
   @override
   Delta? apply(Delta document, int index, Object data) {
@@ -334,17 +334,18 @@ class ForceNewlineForInsertsAroundEmbedRule extends InsertRule {
     final iter = DeltaIterator(document);
     final previous = iter.skip(index);
     final target = iter.next();
-    final cursorBeforeEmbed = isBlockEmbed(target.data);
-    final cursorAfterEmbed = previous != null && isBlockEmbed(previous.data);
+    final cursorBeforeBlockEmbed = isBlockEmbed(target.data);
+    final cursorAfterBlockEmbed =
+        previous != null && isBlockEmbed(previous.data);
 
-    if (cursorBeforeEmbed || cursorAfterEmbed) {
+    if (cursorBeforeBlockEmbed || cursorAfterBlockEmbed) {
       final delta = Delta()..retain(index);
-      if (cursorBeforeEmbed && !data.endsWith('\n')) {
+      if (cursorBeforeBlockEmbed && !data.endsWith('\n')) {
         return delta
           ..insert(data)
           ..insert('\n');
       }
-      if (cursorAfterEmbed && !data.startsWith('\n')) {
+      if (cursorAfterBlockEmbed && !data.startsWith('\n')) {
         return delta
           ..insert('\n')
           ..insert(data);
@@ -441,13 +442,13 @@ class PreserveBlockStyleOnInsertRule extends InsertRule {
   }
 }
 
-/// Handles all format operations which manipulate embeds.
-class InsertEmbedsRule extends InsertRule {
-  const InsertEmbedsRule();
+/// Handles all format operations which manipulate block embeds.
+class InsertBlockEmbedsRule extends InsertRule {
+  const InsertBlockEmbedsRule();
 
   @override
   Delta? apply(Delta document, int index, Object data) {
-    // We are only interested in embeddable objects.
+    // We are only interested in block embeddable objects.
     if (data is String || !isBlockEmbed(data)) return null;
 
     final result = Delta()..retain(index);

--- a/packages/parchment/test/heuristics/insert_rules_test.dart
+++ b/packages/parchment/test/heuristics/insert_rules_test.dart
@@ -318,8 +318,8 @@ void main() {
     });
   });
 
-  group('$InsertEmbedsRule', () {
-    final rule = InsertEmbedsRule();
+  group('$InsertBlockEmbedsRule', () {
+    final rule = InsertBlockEmbedsRule();
 
     test('insert on an empty line', () {
       final doc = Delta()
@@ -380,6 +380,16 @@ void main() {
         ..insert('\n');
       expect(actual, isNotNull);
       expect(actual, expected);
+    });
+
+    test('inserted object is not block embed', () {
+      final doc = Delta()
+        ..insert('One and two\n')
+        ..insert('embed here\n')
+        ..insert('Three')
+        ..insert('\n');
+      expect(rule.apply(doc, 17, 'Some text'), isNull);
+      expect(rule.apply(doc, 17, SpanEmbed('span')), isNull);
     });
   });
 


### PR DESCRIPTION
Current `InsertEmbedsRule` adds a new line after insertion delta if the data is embeddable object but it should only be applied for block embeds since it's just ensuring that embed is on a new line without any other data before and after it.