### PR TITLE
Fix optional FocusNode causing _CastError

### DIFF
--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -1001,9 +1001,7 @@ class RawEditorState extends EditorState
     if (widget.focusNode != oldWidget.focusNode) {
       oldWidget.focusNode?.removeListener(_handleFocusChanged);
       if (widget.focusNode != null) {
-        _internalFocusNode
-          ?..removeListener(_handleFocusChanged)
-          ..dispose();
+        _internalFocusNode?.dispose();
         _internalFocusNode = null;
       }
       effectiveFocusNode.addListener(_handleFocusChanged);

--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -512,7 +512,7 @@ class RawEditor extends StatefulWidget {
       paste: true,
       selectAll: true,
     ),
-    this.cursorStyle,
+    required this.cursorStyle,
     this.showSelectionHandles = false,
     this.selectionControls,
     this.embedBuilder = defaultFleatherEmbedBuilder,
@@ -584,7 +584,7 @@ class RawEditor extends StatefulWidget {
   final bool showCursor;
 
   /// The style to be used for the editing cursor.
-  final CursorStyle? cursorStyle;
+  final CursorStyle cursorStyle;
 
   /// Configures how the platform keyboard will select an uppercase or
   /// lowercase keyboard.
@@ -946,13 +946,7 @@ class RawEditorState extends EditorState
     // Cursor
     _cursorController = CursorController(
       showCursor: ValueNotifier<bool>(widget.showCursor),
-      style: widget.cursorStyle ??
-          const CursorStyle(
-            // TODO: fallback to current theme's accent color
-            color: Colors.blueAccent,
-            backgroundColor: Colors.grey,
-            width: 2.0,
-          ),
+      style: widget.cursorStyle,
       tickerProvider: this,
     );
 
@@ -989,7 +983,7 @@ class RawEditorState extends EditorState
     super.didUpdateWidget(oldWidget);
 
     _cursorController.showCursor.value = widget.showCursor;
-    _cursorController.style = widget.cursorStyle!;
+    _cursorController.style = widget.cursorStyle;
 
     if (widget.controller != oldWidget.controller) {
       oldWidget.controller.removeListener(_didChangeTextEditingValue);

--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -762,11 +762,11 @@ class RawEditorState extends EditorState
 
   bool _didAutoFocus = false;
 
-  FocusNode? _focusNode;
+  FocusNode? _internalFocusNode;
 
   @override
   FocusNode get effectiveFocusNode =>
-      widget.focusNode ?? (_focusNode ??= FocusNode());
+      widget.focusNode ?? (_internalFocusNode ??= FocusNode());
 
   bool get _hasFocus => effectiveFocusNode.hasFocus;
 
@@ -1007,10 +1007,10 @@ class RawEditorState extends EditorState
     if (widget.focusNode != oldWidget.focusNode) {
       oldWidget.focusNode?.removeListener(_handleFocusChanged);
       if (widget.focusNode != null) {
-        _focusNode
+        _internalFocusNode
           ?..removeListener(_handleFocusChanged)
           ..dispose();
-        _focusNode = null;
+        _internalFocusNode = null;
       }
       effectiveFocusNode.addListener(_handleFocusChanged);
       updateKeepAlive();
@@ -1049,7 +1049,7 @@ class RawEditorState extends EditorState
     _selectionOverlay = null;
     widget.controller.removeListener(_didChangeTextEditingValue);
     effectiveFocusNode.removeListener(_handleFocusChanged);
-    _focusNode?.dispose();
+    _internalFocusNode?.dispose();
     _cursorController.dispose();
     _clipboardStatus?.removeListener(_onChangedClipboardStatus);
     _clipboardStatus?.dispose();

--- a/packages/fleather/lib/src/widgets/field.dart
+++ b/packages/fleather/lib/src/widgets/field.dart
@@ -171,26 +171,37 @@ class FleatherField extends StatefulWidget {
 class _FleatherFieldState extends State<FleatherField> {
   late bool _focused;
 
+  FocusNode? _focusNode;
+
+  FocusNode get effectiveFocusNode =>
+      widget.focusNode ?? (_focusNode ??= FocusNode());
+
   void _editorFocusChanged() {
     setState(() {
-      _focused = widget.focusNode!.hasFocus;
+      _focused = effectiveFocusNode.hasFocus;
     });
   }
 
   @override
   void initState() {
     super.initState();
-    _focused = widget.focusNode!.hasFocus;
-    widget.focusNode!.addListener(_editorFocusChanged);
+    _focused = effectiveFocusNode.hasFocus;
+    effectiveFocusNode.addListener(_editorFocusChanged);
   }
 
   @override
   void didUpdateWidget(covariant FleatherField oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.focusNode != oldWidget.focusNode) {
-      oldWidget.focusNode!.removeListener(_editorFocusChanged);
-      widget.focusNode!.addListener(_editorFocusChanged);
-      _focused = widget.focusNode!.hasFocus;
+      oldWidget.focusNode?.removeListener(_editorFocusChanged);
+      if (widget.focusNode != null) {
+        _focusNode
+          ?..removeListener(_editorFocusChanged)
+          ..dispose();
+        _focusNode = null;
+      }
+      effectiveFocusNode.addListener(_editorFocusChanged);
+      _focused = effectiveFocusNode.hasFocus;
     }
   }
 
@@ -199,7 +210,7 @@ class _FleatherFieldState extends State<FleatherField> {
     Widget child = FleatherEditor(
       controller: widget.controller,
       editorKey: widget.editorKey,
-      focusNode: widget.focusNode,
+      focusNode: effectiveFocusNode,
       scrollController: widget.scrollController,
       scrollable: widget.scrollable,
       padding: widget.padding,
@@ -233,12 +244,12 @@ class _FleatherFieldState extends State<FleatherField> {
     }
 
     return AnimatedBuilder(
-      animation:
-          Listenable.merge(<Listenable?>[widget.focusNode, widget.controller]),
+      animation: Listenable.merge(
+          <Listenable?>[effectiveFocusNode, widget.controller]),
       builder: (BuildContext context, Widget? child) {
         return InputDecorator(
           decoration: _getEffectiveDecoration(),
-          isFocused: widget.focusNode!.hasFocus,
+          isFocused: effectiveFocusNode.hasFocus,
           isEmpty: _isEmpty,
           child: child,
         );

--- a/packages/fleather/lib/src/widgets/field.dart
+++ b/packages/fleather/lib/src/widgets/field.dart
@@ -171,10 +171,10 @@ class FleatherField extends StatefulWidget {
 class _FleatherFieldState extends State<FleatherField> {
   late bool _focused;
 
-  FocusNode? _focusNode;
+  FocusNode? _internalFocusNode;
 
   FocusNode get effectiveFocusNode =>
-      widget.focusNode ?? (_focusNode ??= FocusNode());
+      widget.focusNode ?? (_internalFocusNode ??= FocusNode());
 
   void _editorFocusChanged() {
     setState(() {
@@ -195,10 +195,10 @@ class _FleatherFieldState extends State<FleatherField> {
     if (widget.focusNode != oldWidget.focusNode) {
       oldWidget.focusNode?.removeListener(_editorFocusChanged);
       if (widget.focusNode != null) {
-        _focusNode
+        _internalFocusNode
           ?..removeListener(_editorFocusChanged)
           ..dispose();
-        _focusNode = null;
+        _internalFocusNode = null;
       }
       effectiveFocusNode.addListener(_editorFocusChanged);
       _focused = effectiveFocusNode.hasFocus;

--- a/packages/fleather/lib/src/widgets/field.dart
+++ b/packages/fleather/lib/src/widgets/field.dart
@@ -195,9 +195,7 @@ class _FleatherFieldState extends State<FleatherField> {
     if (widget.focusNode != oldWidget.focusNode) {
       oldWidget.focusNode?.removeListener(_editorFocusChanged);
       if (widget.focusNode != null) {
-        _internalFocusNode
-          ?..removeListener(_editorFocusChanged)
-          ..dispose();
+        _internalFocusNode?.dispose();
         _internalFocusNode = null;
       }
       effectiveFocusNode.addListener(_editorFocusChanged);

--- a/packages/fleather/test/widgets/editor_test.dart
+++ b/packages/fleather/test/widgets/editor_test.dart
@@ -85,6 +85,16 @@ void main() {
       await tester.pumpAndSettle();
       expect(editor.document.toPlainText(), '$clipboardText\n');
     });
+
+    testWidgets('editor creates its own focusNode if not provided',
+        (tester) async {
+      final editor = MaterialApp(
+          home: RawEditor(
+              controller: FleatherController(), selectionColor: Colors.blue));
+      await tester.pumpWidget(editor);
+      final state = tester.state<RawEditorState>(find.byType(RawEditor));
+      expect(state.effectiveFocusNode, isA<FocusNode>());
+    });
   });
 }
 

--- a/packages/fleather/test/widgets/editor_test.dart
+++ b/packages/fleather/test/widgets/editor_test.dart
@@ -86,14 +86,21 @@ void main() {
       expect(editor.document.toPlainText(), '$clipboardText\n');
     });
 
-    testWidgets('editor creates its own focusNode if not provided',
+    testWidgets('creating editor without focusNode does not throw _CastError',
         (tester) async {
-      final editor = MaterialApp(
+      final widget = MaterialApp(
           home: RawEditor(
               controller: FleatherController(), selectionColor: Colors.blue));
-      await tester.pumpWidget(editor);
-      final state = tester.state<RawEditorState>(find.byType(RawEditor));
-      expect(state.effectiveFocusNode, isA<FocusNode>());
+      await tester.pumpWidget(widget);
+      expect(true, true);
+    });
+
+    testWidgets('creating field without focusNode does not throw _CastError',
+        (tester) async {
+      final widget =
+          MaterialApp(home: FleatherField(controller: FleatherController()));
+      await tester.pumpWidget(widget);
+      expect(true, true);
     });
   });
 }

--- a/packages/fleather/test/widgets/editor_test.dart
+++ b/packages/fleather/test/widgets/editor_test.dart
@@ -102,7 +102,7 @@ void main() {
         ),
       );
       await tester.pumpWidget(widget);
-          // Fails if thrown
+      // Fails if thrown
     });
 
     group('didUpdateWidget', () {

--- a/packages/fleather/test/widgets/editor_test.dart
+++ b/packages/fleather/test/widgets/editor_test.dart
@@ -88,21 +88,73 @@ void main() {
 
     testWidgets('creating editor without focusNode does not throw _CastError',
         (tester) async {
-      final widget = MaterialApp(
-          home: RawEditor(
-              controller: FleatherController(), selectionColor: Colors.blue));
+      final widget =
+          MaterialApp(home: FleatherEditor(controller: FleatherController()));
       await tester.pumpWidget(widget);
-      expect(true, true);
+      // Fails if thrown
     });
 
     testWidgets('creating field without focusNode does not throw _CastError',
         (tester) async {
-      final widget =
-          MaterialApp(home: FleatherField(controller: FleatherController()));
+      final widget = MaterialApp(
+        home: FleatherField(
+          controller: FleatherController(),
+        ),
+      );
       await tester.pumpWidget(widget);
-      expect(true, true);
+          // Fails if thrown
+    });
+
+    group('didUpdateWidget', () {
+      testWidgets(
+          'changes focus node when updating widget with internal focus node',
+          (tester) async {
+        final expFocus = FocusNode();
+        final widget =
+            MaterialApp(home: TestUpdateWidget(focusNodeAfterChange: expFocus));
+        await tester.pumpWidget(widget);
+        final initialState =
+            tester.state<RawEditorState>(find.byType(RawEditor));
+        final defaultFocusNode = initialState.effectiveFocusNode;
+        expect(defaultFocusNode, isNot(expFocus));
+        await tester.tap(find.byType(TextButton));
+        await tester.pumpAndSettle();
+        final endState = tester.state<RawEditorState>(find.byType(RawEditor));
+        final actFocusNode = endState.effectiveFocusNode;
+        expect(actFocusNode, expFocus);
+      });
     });
   });
+}
+
+class TestUpdateWidget extends StatefulWidget {
+  const TestUpdateWidget({Key? key, required this.focusNodeAfterChange})
+      : super(key: key);
+
+  final FocusNode focusNodeAfterChange;
+
+  @override
+  State<StatefulWidget> createState() => TestUpdateWidgetState();
+}
+
+class TestUpdateWidgetState extends State<TestUpdateWidget> {
+  FocusNode? focusNode;
+
+  @override
+  Widget build(BuildContext context) => Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextButton(
+            onPressed: () =>
+                setState(() => focusNode = widget.focusNodeAfterChange),
+            child: const Text('Change state'),
+          ),
+          FleatherEditor(
+            controller: FleatherController(),
+            focusNode: focusNode,
+          ),
+        ],
+      );
 }
 
 const clipboardText = 'copied text';


### PR DESCRIPTION
Although providing `focusNode` is optional for both `FleatherEditor` and `FleatherField` but passing null causes `_CastError`.