### PR TITLE
Release v1.2.2

### DIFF
--- a/packages/fleather/CHANGELOG.md
+++ b/packages/fleather/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.2.2
+
+* New example for Fleather
+* Improve checkbox design
+* [Fix] new line after inline embed insertion
+* [Fix] null focusNode causing _CastError
+
 ## 1.2.1
 
 * [Fix] toolbar not showing up on empty documents

--- a/packages/fleather/example/pubspec.yaml
+++ b/packages/fleather/example/pubspec.yaml
@@ -15,10 +15,6 @@ dependencies:
   fleather:
     path: ../
 
-dependency_overrides:
-  parchment:
-    path: ../../parchment
-
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/fleather/pubspec.yaml
+++ b/packages/fleather/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fleather
 description: Clean, minimalistic and collaboration-ready rich text editor for Flutter.
-version: 1.2.1
+version: 1.2.2
 homepage: https://github.com/fleather-editor/fleather
 publish_to: none
 

--- a/packages/parchment/CHANGELOG.md
+++ b/packages/parchment/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+
+* [Fix] new line after inline embed insertion
+
 ## 1.2.0
 
 * Support for background color

--- a/packages/parchment/pubspec.yaml
+++ b/packages/parchment/pubspec.yaml
@@ -1,6 +1,6 @@
 name: parchment
 description: Platform-agnostic rich text document model based on Delta format and used in Fleather editor.
-version: 1.2.0
+version: 1.2.1
 homepage: https://github.com/fleather-editor/fleather
 
 environment:


### PR DESCRIPTION
Removed dependency override of local Parchment from example since it depends on local Fleather and local Fleather depends on local Parchment. So no need for that anymore.