### PR TITLE
Support document history

### DIFF
--- a/.github/workflows/fleather.yml
+++ b/.github/workflows/fleather.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.0.1"
+          flutter-version: "3.3.2"
           cache: true
           # Manually Update this `key`
           cache-key: "20220721"
@@ -35,7 +35,7 @@ jobs:
 
       - name: Parchment - Run tests
         working-directory: ./packages/parchment
-        run: | 
+        run: |
           dart test --coverage coverage
           dart pub global run coverage:format_coverage --lcov --in ./coverage --out ./coverage/lcov.info --report-on:lib
 
@@ -59,11 +59,9 @@ jobs:
       - name: Fleather - Run tests
         working-directory: ./packages/fleather
         run: flutter test --coverage
-        
+
       - name: Codecov
         uses: codecov/codecov-action@v3.1.0
         with:
           files: ./packages/fleather/coverage/lcov.info,./packages/parchment/coverage/lcov.info
           fail_ci_if_error: true
-
-

--- a/packages/fleather/example/macos/Podfile.lock
+++ b/packages/fleather/example/macos/Podfile.lock
@@ -14,7 +14,7 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
-  FlutterMacOS: 57701585bf7de1b3fc2bb61f6378d73bbdea8424
+  FlutterMacOS: ae6af50a8ea7d6103d888583d46bd8328a7e9811
   url_launcher_macos: 597e05b8e514239626bcf4a850fcf9ef5c856ec3
 
 PODFILE CHECKSUM: 6eac6b3292e5142cfc23bdeb71848a40ec51c14c

--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -18,6 +18,7 @@ import 'editable_text_block.dart';
 import 'editable_text_line.dart';
 import 'editor_input_client_mixin.dart';
 import 'editor_selection_delegate_mixin.dart';
+import 'history.dart';
 import 'keyboard_listener.dart';
 import 'link.dart';
 import 'shortcuts.dart';
@@ -356,7 +357,12 @@ class _FleatherEditorState extends State<FleatherEditor>
     );
 
     child = FleatherShortcuts(
-      child: FleatherActions(child: child),
+      child: FleatherActions(
+        child: FleatherHistory(
+          controller: widget.controller,
+          child: child,
+        ),
+      ),
     );
 
     return _selectionGestureDetectorBuilder.buildGestureDetector(

--- a/packages/fleather/lib/src/widgets/editor_selection_delegate_mixin.dart
+++ b/packages/fleather/lib/src/widgets/editor_selection_delegate_mixin.dart
@@ -1,8 +1,8 @@
 import 'dart:math';
 
+import 'package:fleather/util.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/rendering.dart';
-import 'package:fleather/util.dart';
 
 import 'editor.dart';
 
@@ -14,7 +14,8 @@ mixin RawEditorStateSelectionDelegateMixin on EditorState
   }
 
   @override
-  set textEditingValue(TextEditingValue value) {
+  void userUpdateTextEditingValue(
+      TextEditingValue value, SelectionChangedCause cause) {
     final cursorPosition = value.selection.extentOffset;
     final oldText = widget.controller.document.toPlainText();
     final newText = value.text;
@@ -22,12 +23,6 @@ mixin RawEditorStateSelectionDelegateMixin on EditorState
     widget.controller.replaceText(
         diff.start, diff.deleted.length, diff.inserted,
         selection: value.selection);
-  }
-
-  @override
-  void userUpdateTextEditingValue(
-      TextEditingValue value, SelectionChangedCause cause) {
-    textEditingValue = value;
   }
 
   @override

--- a/packages/fleather/lib/src/widgets/history.dart
+++ b/packages/fleather/lib/src/widgets/history.dart
@@ -33,8 +33,8 @@ class FleatherHistory extends StatefulWidget {
 }
 
 class _FleatherHistoryState extends State<FleatherHistory> {
-  late final HistoryStack _stack;
   late final _Throttled<Delta> _throttledPush;
+  late HistoryStack _stack;
   Timer? _throttleTimer;
 
   // This duration was chosen as a best fit for the behavior of Mac, Linux,

--- a/packages/fleather/lib/src/widgets/history.dart
+++ b/packages/fleather/lib/src/widgets/history.dart
@@ -1,0 +1,317 @@
+import 'dart:async';
+
+import 'package:fleather/fleather.dart';
+import 'package:flutter/widgets.dart';
+import 'package:quill_delta/quill_delta.dart';
+
+/// A void function that takes a [TextEditingValue].
+@visibleForTesting
+typedef TextEditingValueCallback = void Function(TextEditingValue value);
+
+/// Provides undo/redo capabilities for text editing.
+///
+/// Listens to [controller] as a [ValueNotifier] and saves relevant values for
+/// undoing/redoing. The cadence at which values are saved is a best
+/// approximation of the native behaviors of a hardware keyboard on Flutter's
+/// desktop platforms, as there are subtle differences between each of these
+/// platforms.
+///
+/// Listens to keyboard undo/redo shortcuts and send update to [controller].
+class FleatherHistory extends StatefulWidget {
+  /// Creates an instance of [FleatherHistory].
+  const FleatherHistory(
+      {super.key, required this.child, required this.controller});
+
+  /// The child widget of [FleatherHistory].
+  final Widget child;
+
+  /// The [FleatherController] to save the state of over time.
+  final FleatherController controller;
+
+  @override
+  State<FleatherHistory> createState() => _FleatherHistoryState();
+}
+
+class _FleatherHistoryState extends State<FleatherHistory> {
+  late final HistoryStack _stack;
+  late final _Throttled<Delta> _throttledPush;
+  Timer? _throttleTimer;
+
+  // This duration was chosen as a best fit for the behavior of Mac, Linux,
+  // and Windows undo/redo state save durations, but it is not perfect for any
+  // of them.
+  static const Duration _kThrottleDuration = Duration(milliseconds: 500);
+
+  void _undo(UndoTextIntent intent) {
+    _update(_stack.undo());
+  }
+
+  void _redo(RedoTextIntent intent) {
+    _update(_stack.redo());
+  }
+
+  void _update(Delta? changeDelta) {
+    if (changeDelta == null || changeDelta.isEmpty) {
+      return;
+    }
+
+    widget.controller.compose(changeDelta,
+        selection: _fromDelta(changeDelta), source: ChangeSource.local);
+  }
+
+  TextSelection _fromDelta(Delta changeDelta) {
+    assert(changeDelta.isNotEmpty);
+    final firstOp = changeDelta.first;
+    int baseOffset = 0;
+    if (firstOp.isRetain && firstOp.attributes == null) {
+      baseOffset = firstOp.length;
+    }
+    int extentOffset = baseOffset;
+    final lastOp = changeDelta.last;
+    if (lastOp.isRetain && lastOp.attributes != null) {
+      extentOffset = changeDelta.textLength;
+    }
+    if (lastOp.isInsert) {
+      baseOffset = changeDelta.textLength;
+      extentOffset = baseOffset;
+    }
+    return TextSelection(baseOffset: baseOffset, extentOffset: extentOffset);
+  }
+
+  void _push() {
+    if (widget.controller.plainTextEditingValue == TextEditingValue.empty) {
+      return;
+    }
+    _throttleTimer = _throttledPush(widget.controller.document.toDelta());
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _stack = HistoryStack(widget.controller.document.toDelta());
+    _throttledPush =
+        _throttle(duration: _kThrottleDuration, function: _stack.push);
+    widget.controller.addListener(_push);
+  }
+
+  @override
+  void didUpdateWidget(FleatherHistory oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.controller != oldWidget.controller) {
+      _stack = HistoryStack(widget.controller.document.toDelta());
+      oldWidget.controller.removeListener(_push);
+      widget.controller.addListener(_push);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_push);
+    _throttleTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Actions(
+      actions: <Type, Action<Intent>>{
+        UndoTextIntent: Action<UndoTextIntent>.overridable(
+            context: context,
+            defaultAction: CallbackAction<UndoTextIntent>(onInvoke: _undo)),
+        RedoTextIntent: Action<RedoTextIntent>.overridable(
+            context: context,
+            defaultAction: CallbackAction<RedoTextIntent>(onInvoke: _redo)),
+      },
+      child: widget.child,
+    );
+  }
+}
+
+/// A data structure representing a chronological list of states that can be
+/// undone and redone.
+/// Initial state of the stack contains the document [Delta] at the time of
+/// instantiation
+class HistoryStack {
+  /// Creates an instance of [HistoryStack].
+  HistoryStack(this._initialState) : _currentState = _initialState;
+
+  // State of the document upon loading
+  final Delta _initialState;
+
+  // List of historical changes made to document
+  final List<_Change> _list = [];
+
+  // The index of the current value, or -1 if the list is empty.
+  int _currentIndex = -1;
+
+  Delta _currentState;
+
+  _Change? get _currentChange => _list.isEmpty ? null : _list[_currentIndex];
+
+  /// Add a new document state change to the stack.
+  void push(Delta newState) {
+    final redoDelta = _currentState.diff(newState);
+
+    if (redoDelta.isEmpty) return;
+
+    final undoDelta = redoDelta.invert(_currentState);
+
+    _currentState = newState;
+
+    if (_list.isEmpty) {
+      _currentIndex = 0;
+      _list.add(_Change(undoDelta, redoDelta));
+      return;
+    }
+
+    assert(_currentIndex < _list.length && _currentIndex >= -1);
+
+    // If anything has been undone in this stack, remove those irrelevant states
+    // before adding the new one.
+    if (_currentIndex != _list.length - 1) {
+      _list.removeRange(_currentIndex + 1, _list.length);
+    }
+    _list.add(_Change(undoDelta, redoDelta));
+    _currentIndex = _list.length - 1;
+  }
+
+  /// Returns the current [_Change] to apply to current document to reach desired
+  /// document state.
+  ///
+  /// An undo operation moves the current value to the previously pushed value,
+  /// if any.
+  ///
+  /// Iff the stack is completely empty, then returns null.
+  Delta? undo() {
+    if (_list.isEmpty) {
+      return null;
+    }
+    assert(_currentIndex < _list.length && _currentIndex >= -1);
+    if (_currentIndex == -1) {
+      return null;
+    }
+    final undoDelta = _currentChange!.undoDelta;
+    _currentState = _currentState.compose(undoDelta);
+    _currentIndex = _currentIndex - 1;
+    return undoDelta;
+  }
+
+  /// Returns the current [_Change] to apply to current document to reach desired
+  /// document state.
+  ///
+  /// A redo operation moves the current value to the value that was last
+  /// undone, if any.
+  ///
+  /// Iff the stack is completely empty, then returns null.
+  Delta? redo() {
+    if (_list.isEmpty) {
+      return null;
+    }
+    assert(_currentIndex < _list.length && _currentIndex >= -1);
+    if (_currentIndex < _list.length - 1) {
+      _currentIndex = _currentIndex + 1;
+      final redoDelta = _currentChange!.redoDelta;
+      _currentState = _currentState.compose(redoDelta);
+      return redoDelta;
+    }
+    return null;
+  }
+
+  /// Remove everything from the stack.
+  void clear() {
+    _list.clear();
+    _currentIndex = -1;
+    _currentState = _initialState;
+  }
+
+  @override
+  String toString() {
+    return '_UndoStack $_list';
+  }
+}
+
+/// Stores undo & redo [Delta] from current document [Delta] state
+/// Both need to be stored in order to replay or rewind history without
+/// having to store complete versions of the document
+class _Change {
+  _Change(this.undoDelta, this.redoDelta);
+
+  final Delta undoDelta;
+  final Delta redoDelta;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _Change &&
+          runtimeType == other.runtimeType &&
+          undoDelta == other.undoDelta &&
+          redoDelta == other.redoDelta;
+
+  @override
+  int get hashCode => undoDelta.hashCode ^ redoDelta.hashCode;
+
+  @override
+  String toString() {
+    return '''
+Change{
+  undoDelta: 
+$undoDelta, 
+  redoDelta: 
+$redoDelta
+}''';
+  }
+}
+
+/// A function that can be throttled with the throttle function.
+typedef _Throttleable<T> = void Function(T currentArg);
+
+/// A function that has been throttled by [_throttle].
+typedef _Throttled<T> = Timer Function(T currentArg);
+
+/// Returns a _Throttled that will call through to the given function only a
+/// maximum of once per duration.
+///
+/// Only works for functions that take exactly one argument and return void.
+_Throttled<T> _throttle<T>({
+  required Duration duration,
+  required _Throttleable<T> function,
+  // If true, calls at the start of the timer.
+  bool leadingEdge = false,
+}) {
+  Timer? timer;
+  bool calledDuringTimer = false;
+  late T arg;
+
+  return (T currentArg) {
+    arg = currentArg;
+    if (timer != null) {
+      calledDuringTimer = true;
+      return timer!;
+    }
+    if (leadingEdge) {
+      function(arg);
+    }
+    calledDuringTimer = false;
+    timer = Timer(duration, () {
+      if (!leadingEdge || calledDuringTimer) {
+        function(arg);
+      }
+      timer = null;
+    });
+    return timer!;
+  };
+}
+
+extension on Delta {
+  int get textLength {
+    int length = 0;
+    toList().forEach((op) {
+      if (op.isDelete) {
+        length -= op.length;
+      } else {
+        length += op.length;
+      }
+    });
+    return length;
+  }
+}

--- a/packages/fleather/lib/src/widgets/history.dart
+++ b/packages/fleather/lib/src/widgets/history.dart
@@ -4,10 +4,6 @@ import 'package:fleather/fleather.dart';
 import 'package:flutter/widgets.dart';
 import 'package:quill_delta/quill_delta.dart';
 
-/// A void function that takes a [TextEditingValue].
-@visibleForTesting
-typedef TextEditingValueCallback = void Function(TextEditingValue value);
-
 /// Provides undo/redo capabilities for text editing.
 ///
 /// Listens to [controller] as a [ValueNotifier] and saves relevant values for

--- a/packages/fleather/lib/src/widgets/history.dart
+++ b/packages/fleather/lib/src/widgets/history.dart
@@ -133,10 +133,7 @@ class _FleatherHistoryState extends State<FleatherHistory> {
 /// instantiation
 class HistoryStack {
   /// Creates an instance of [HistoryStack].
-  HistoryStack(this._initialState) : _currentState = _initialState;
-
-  // State of the document upon loading
-  final Delta _initialState;
+  HistoryStack(this._currentState);
 
   // List of historical changes made to document
   final List<_Change> _list = [];
@@ -216,18 +213,6 @@ class HistoryStack {
     }
     return null;
   }
-
-  /// Remove everything from the stack.
-  void clear() {
-    _list.clear();
-    _currentIndex = -1;
-    _currentState = _initialState;
-  }
-
-  @override
-  String toString() {
-    return '_UndoStack $_list';
-  }
 }
 
 /// Stores undo & redo [Delta] from current document [Delta] state
@@ -238,28 +223,6 @@ class _Change {
 
   final Delta undoDelta;
   final Delta redoDelta;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is _Change &&
-          runtimeType == other.runtimeType &&
-          undoDelta == other.undoDelta &&
-          redoDelta == other.redoDelta;
-
-  @override
-  int get hashCode => undoDelta.hashCode ^ redoDelta.hashCode;
-
-  @override
-  String toString() {
-    return '''
-Change{
-  undoDelta: 
-$undoDelta, 
-  redoDelta: 
-$redoDelta
-}''';
-  }
 }
 
 /// A function that can be throttled with the throttle function.

--- a/packages/fleather/lib/src/widgets/shortcuts.dart
+++ b/packages/fleather/lib/src/widgets/shortcuts.dart
@@ -40,14 +40,14 @@ class FleatherShortcuts extends Shortcuts {
         ToggleUnderlineStyleIntent(),
   };
 
-  static final Map<ShortcutActivator, Intent> _macShortcuts =
+  static const Map<ShortcutActivator, Intent> _macShortcuts =
       <ShortcutActivator, Intent>{
-    const SingleActivator(LogicalKeyboardKey.keyB, meta: true):
-        const ToggleBoldStyleIntent(),
-    const SingleActivator(LogicalKeyboardKey.keyI, meta: true):
-        const ToggleItalicStyleIntent(),
-    const SingleActivator(LogicalKeyboardKey.keyU, meta: true):
-        const ToggleUnderlineStyleIntent(),
+    SingleActivator(LogicalKeyboardKey.keyB, meta: true):
+        ToggleBoldStyleIntent(),
+    SingleActivator(LogicalKeyboardKey.keyI, meta: true):
+        ToggleItalicStyleIntent(),
+    SingleActivator(LogicalKeyboardKey.keyU, meta: true):
+        ToggleUnderlineStyleIntent(),
   };
 }
 

--- a/packages/fleather/pubspec.yaml
+++ b/packages/fleather/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/fleather-editor/fleather
 publish_to: none
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/packages/fleather/test/testing.dart
+++ b/packages/fleather/test/testing.dart
@@ -2,10 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:fleather/fleather.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:quill_delta/quill_delta.dart';
-import 'package:fleather/fleather.dart';
 
 var delta = Delta()..insert('This House Is A Circus\n');
 
@@ -107,6 +107,22 @@ class EditorSandBox {
     final button = tester.widget(find.widgetWithText(RawMaterialButton, text))
         as RawMaterialButton;
     return button;
+  }
+
+  Future<void> enterText(TextEditingValue text) async {
+    return TestAsyncUtils.guard<void>(() async {
+      await showKeyboard();
+      tester.binding.testTextInput.updateEditingValue(text);
+      await tester.idle();
+    });
+  }
+
+  Future<void> showKeyboard() async {
+    return TestAsyncUtils.guard<void>(() async {
+      final editor = tester.state<RawEditorState>(find.byType(RawEditor));
+      editor.requestKeyboard();
+      await pump();
+    });
   }
 }
 

--- a/packages/fleather/test/widgets/history_test.dart
+++ b/packages/fleather/test/widgets/history_test.dart
@@ -1,6 +1,28 @@
+import 'package:fleather/fleather.dart';
 import 'package:fleather/src/widgets/history.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:quill_delta/quill_delta.dart';
+
+import '../testing.dart';
+
+Future<void> undo(WidgetTester tester) async {
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.keyZ);
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.keyZ);
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
+  await tester.pumpAndSettle();
+}
+
+Future<void> redo(WidgetTester tester) async {
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+  await tester.sendKeyDownEvent(LogicalKeyboardKey.keyZ);
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.keyZ);
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+  await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
+  await tester.pumpAndSettle();
+}
 
 void main() {
   group('History stack', () {
@@ -96,6 +118,77 @@ void main() {
       final base = Delta()..insert('Hello\n');
       final inc = Delta()..retain(5, {'b': true});
       expect(inc.invert(base), Delta()..retain(5, {'b': null}));
+    });
+  });
+
+  group('History widget', () {
+    testWidgets('undo/redo insertion', (tester) async {
+      const initialLength = 'Something in the way mmmmm'.length;
+      final documentDelta = Delta()
+        ..insert('Something', {'b': true})
+        ..insert(' in the way ')
+        ..insert('mmmmm', {'i': true})
+        ..insert('\n');
+      final editor = EditorSandBox(
+          tester: tester, document: ParchmentDocument.fromDelta(documentDelta));
+      final endState = documentDelta.compose(Delta()
+        ..retain(initialLength - 5)
+        ..delete(5)
+        ..insert('mmmmm,', {'i': true}));
+      await editor.pump();
+      await editor.enterText(const TextEditingValue(
+          text: 'Something in the way mmmmm,\n',
+          selection: TextSelection.collapsed(offset: 26)));
+      // Throttle time of 500ms in history
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pumpAndSettle();
+      expect(editor.controller.document.toDelta(), endState);
+
+      await undo(tester);
+      expect(editor.controller.document.toDelta(), documentDelta);
+      expect(editor.controller.selection,
+          const TextSelection.collapsed(offset: initialLength));
+
+      await redo(tester);
+      expect(editor.controller.document.toDelta(), endState);
+      expect(editor.controller.selection,
+          const TextSelection.collapsed(offset: initialLength + 1));
+    });
+
+    testWidgets('undo/redo formatting', (tester) async {
+      const initialLength = 'Something in the way mmmmm'.length;
+      final documentDelta = Delta()
+        ..insert('Something', {'b': true})
+        ..insert(' in the way ')
+        ..insert('mmmmm', {'i': true})
+        ..insert('\n');
+      final editor = EditorSandBox(
+          tester: tester, document: ParchmentDocument.fromDelta(documentDelta));
+      final endState = documentDelta.compose(Delta()
+        ..retain(initialLength - 5)
+        ..delete(5)
+        ..insert('mmmmm'));
+      await editor.pump();
+      editor.controller
+          .formatText(initialLength - 5, 5, ParchmentAttribute.italic.unset);
+      // Throttle time of 500ms in history
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pumpAndSettle();
+      expect(editor.controller.document.toDelta(), endState);
+
+      await undo(tester);
+      expect(editor.controller.document.toDelta(), documentDelta);
+      expect(
+          editor.controller.selection,
+          const TextSelection(
+              baseOffset: initialLength - 5, extentOffset: initialLength));
+
+      await redo(tester);
+      expect(editor.controller.document.toDelta(), endState);
+      expect(
+          editor.controller.selection,
+          const TextSelection(
+              baseOffset: initialLength - 5, extentOffset: initialLength));
     });
   });
 }

--- a/packages/fleather/test/widgets/history_test.dart
+++ b/packages/fleather/test/widgets/history_test.dart
@@ -1,0 +1,101 @@
+import 'package:fleather/src/widgets/history.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:quill_delta/quill_delta.dart';
+
+void main() {
+  group('History stack', () {
+    late HistoryStack stack;
+
+    setUp(() {
+      stack = HistoryStack(Delta()..insert('Hello\n'));
+    });
+
+    group('empty stack', () {
+      test('undo returns null', () {
+        expect(stack.undo(), isNull);
+      });
+
+      test('redo returns null', () {
+        expect(stack.redo(), isNull);
+      });
+    });
+
+    test('undoes twice', () {
+      final change = Delta()..insert('Hello world\n');
+      final otherChange = Delta()..insert('Hello world ok\n');
+      final exp = Delta()
+        ..retain(5)
+        ..delete(6);
+      final expOther = Delta()
+        ..retain(11)
+        ..delete(3);
+      stack.push(change);
+      stack.push(otherChange);
+      var act = stack.undo();
+      expect(act, expOther);
+      act = stack.undo();
+      expect(act, exp);
+    });
+
+    test('undoes too many times', () {
+      final change = Delta()..insert('Hello world\n');
+      stack.push(change);
+      var act = stack.undo();
+      expect(act, isNotNull);
+      act = stack.undo();
+      expect(act, isNull);
+    });
+
+    test('redoes twice', () {
+      final change = Delta()..insert('Hello world\n');
+      final otherChange = Delta()..insert('Hello world ok\n');
+      final exp = Delta()
+        ..retain(5)
+        ..insert(' world');
+      final expOther = Delta()
+        ..retain(11)
+        ..insert(' ok');
+      stack.push(change);
+      stack.push(otherChange);
+      stack.undo();
+      stack.undo();
+      var act = stack.redo();
+      expect(act, exp);
+      act = stack.redo();
+      expect(act, expOther);
+    });
+
+    test('redoes too many times', () {
+      final change = Delta()..insert('Hello world\n');
+      stack.push(change);
+      stack.undo();
+      var act = stack.redo();
+      expect(act, isNotNull);
+      act = stack.redo();
+      expect(act, isNull);
+    });
+
+    test('pushes new items while index is at start', () {
+      final change = Delta()..insert('Hello world\n');
+      stack.push(change);
+      expect(stack.undo(), isNotNull);
+      stack.push(change);
+      expect(stack.redo(), isNull);
+    });
+
+    test('undoing formatting', () {
+      final change = Delta()
+        ..insert('Hello', {'b': true})
+        ..insert('\n');
+      stack.push(change);
+      var act = stack.undo();
+      expect(act, Delta()..retain(5, {'b': null}));
+    });
+
+    test('Delta', () {
+      final base = Delta()..insert('Hello\n');
+      final inc = Delta()..retain(5, {'b': true});
+      expect(inc.invert(base), Delta()..retain(5, {'b': null}));
+    });
+  });
+}


### PR DESCRIPTION
Support undoing & redoing a document's history using default shortcuts of the platform (`ctrl+z`, `ctrl+shift+z`, etc..)
