### PR TITLE
force a refresh when focus changes

### DIFF
--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -1134,6 +1134,9 @@ class RawEditorState extends EditorState
       // Place cursor at the end if the selection is invalid when we receive focus.
 //        _handleSelectionChanged(TextSelection.collapsed(offset: _value.text.length), renderEditable, null);
 //      }
+      setState(() {
+        // Inform the widget that the value of focus has changed. (so that cursor can repaint appropriately)
+      });
     } else {
       WidgetsBinding.instance.removeObserver(this);
       // TODO: teach editor about state of the toolbar and whether the user is in the middle of applying styles.


### PR DESCRIPTION
otherwise _hasFocus for EditableTextLine is false while the widget has the focus and the cursor is not displayed.

This is triggered when the text field is empty. (not always, but most of the time).

In practice: you click on an empty Fleather editor and nothing happens. (the cursor doesn't start blinking).
I also tried to remove the the _hasFocus check from https://github.com/fleather-editor/fleather/blob/master/packages/fleather/lib/src/rendering/editable_text_line.dart#L731 and it worked perfectly from my test. (not printing the cursor when it was not needed...so if you know what is best...)