### PR TITLE
Support for HTML decoding/encoding

### DIFF
--- a/packages/parchment/lib/src/convert/html.dart
+++ b/packages/parchment/lib/src/convert/html.dart
@@ -1,0 +1,881 @@
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:html/dom.dart' as html;
+import 'package:html/parser.dart';
+import 'package:parchment/parchment.dart';
+import 'package:quill_delta/quill_delta.dart';
+
+extension on ParchmentStyle {
+  Iterable<ParchmentAttribute> get lineAttributes =>
+      values.where((e) => e.scope == ParchmentAttributeScope.line);
+
+  Iterable<ParchmentAttribute> get inlineAttributes =>
+      values.where((e) => e.scope == ParchmentAttributeScope.inline);
+}
+
+final _inlineAttributesParchmentToHtml = {
+  ParchmentAttribute.bold.key: 'strong',
+  ParchmentAttribute.italic.key: 'em',
+  ParchmentAttribute.underline.key: 'u',
+  ParchmentAttribute.strikethrough.key: 'del',
+  ParchmentAttribute.inlineCode.key: 'code',
+  ParchmentAttribute.link.key: 'a',
+};
+
+const _indentWidthInPx = 32;
+
+/// HTML conversion of Parchment
+///
+/// *note: `<br>` are not recognized as new lines and will be ignored*
+///
+/// ## Inline mapping
+/// - b -> <strong>
+/// - i -> <em>
+/// - u -> <u>
+/// - s -> <del>
+/// - c -> <code>
+/// - a -> <a>
+///
+/// ### Line mapping
+/// - default -> <p>
+/// - heading X -> <hX>
+/// - bq -> <blockquote>
+/// - code -> <pre><code>
+/// - ol -> <ol><li>
+/// - ul -> <ul><li>
+/// - cl -> <div class="checklist">
+///           <div class"checklist-item><input type="checklist" checked><label>
+/// - alignment -> <xxx align="left | right | center | justify">
+/// - direction -> <xxx dir="rtl">
+///
+class ParchmentHtmlCodec extends Codec<Delta, String> {
+  const ParchmentHtmlCodec();
+
+  @override
+  Converter<String, Delta> get decoder => const _ParchmentHtmlDecoder();
+
+  @override
+  Converter<Delta, String> get encoder => const _ParchmentHtmlEncoder();
+}
+
+// Inline tags related directly to ParchmentAttributeScope.inline.
+// While iterating through operations, when within a line, one can only know if
+// the corresponding HTML tag is open. Only when the operation doesn't have the
+// attribute can we know that the tag should have been closed at the previous iteration.
+//
+// Line tags are related to attributes with line scope but that cannot
+// contains more than one line (such as heading, blockquote, paragraphs).
+// While iterating through operations, one can only know if the corresponding
+// HTML tag is open. Only when the operation corresponds to a new line can we
+// know that the tag should have be closed at the start of the current operation.
+//
+// Block tags are line Parchment attributes that can contain several lines.
+// These can be code or lists.
+// These behave almost as line tags except there can be nested blocks
+class _ParchmentHtmlEncoder extends Converter<Delta, String> {
+  const _ParchmentHtmlEncoder();
+
+  static bool isPlainIgnoringCSSAndHtmlAttribute(ParchmentStyle style) {
+    if (style.isEmpty) return true;
+    for (final key in style.keys) {
+      if (key == ParchmentAttribute.alignment.key) continue;
+      if (key == ParchmentAttribute.direction.key) continue;
+      if (key == ParchmentAttribute.indent.key) continue;
+      return false;
+    }
+    return true;
+  }
+
+  // For lists and block code, new lines do not mean a new block
+  static bool isSameBlock(_HtmlBlockTag previous, _HtmlBlockTag current) {
+    final p = previous.style.values;
+    final c = current.style.values;
+    final areOrderedUnorderedLists = (p.contains(ParchmentAttribute.ol) ||
+            p.contains(ParchmentAttribute.ul)) &&
+        (c.contains(ParchmentAttribute.ol) ||
+            c.contains(ParchmentAttribute.ul));
+    final areChecklists =
+        p.contains(ParchmentAttribute.cl) && c.contains(ParchmentAttribute.cl);
+    if (areOrderedUnorderedLists || areChecklists) {
+      final cssAttributes = [
+        ParchmentAttribute.alignment.unset,
+        ParchmentAttribute.alignment.center,
+        ParchmentAttribute.alignment.right,
+        ParchmentAttribute.alignment.justify,
+        ParchmentAttribute.direction.rtl,
+        ParchmentAttribute.direction.unset,
+      ];
+      final modifiedPrevious = previous.style.removeAll(cssAttributes);
+      final modifiedCurrent = current.style.removeAll(cssAttributes);
+      return modifiedCurrent == modifiedPrevious;
+    }
+    // block code
+    if (p.contains(ParchmentAttribute.code) &&
+        c.contains(ParchmentAttribute.code)) return true;
+    return false;
+  }
+
+  // current and candidate are both blocks
+  static bool isNestedList(ParchmentStyle parent, ParchmentStyle child) {
+    final currentListAttribute = parent.values.firstWhereOrNull(
+        (e) => e == ParchmentAttribute.ol || e == ParchmentAttribute.ul);
+    final candidateListAttribute = child.values.firstWhereOrNull(
+        (e) => e == ParchmentAttribute.ol || e == ParchmentAttribute.ul);
+
+    if (currentListAttribute == null || candidateListAttribute == null) {
+      return false;
+    }
+
+    int currentLevel = parent.values
+            .firstWhere((e) => e.key == ParchmentAttribute.indent.key,
+                orElse: () => ParchmentAttribute.indent.withLevel(0))
+            .value ??
+        0;
+    int candidateLevel = child.values
+            .firstWhere((e) => e.key == ParchmentAttribute.indent.key,
+                orElse: () => ParchmentAttribute.indent.withLevel(0))
+            .value ??
+        0;
+    return currentLevel < candidateLevel;
+  }
+
+  @override
+  String convert(Delta input) {
+    StringBuffer buffer = StringBuffer();
+    // Stack on inline tags
+    final List<_HtmlInlineTag> openInlineTags = [];
+    // Stack of blocks currently being processed
+    // The first element of the stack is the last block that occurred in the
+    // operations. When an operation with a different block comes up, the html
+    // of the first element are written to the buffer and the first element is
+    // replaced by the new block.
+    //
+    // Multiple items in the stack means nested blocks are being handled.
+    final List<_HtmlBlockTag> openBlockTags = [];
+    int nextLineStartPosition = 0;
+
+    for (final op in input.toList()) {
+      if (_hasPlainParagraph(op)) {
+        _processInlineTags(op, buffer, openInlineTags);
+        nextLineStartPosition = _handlePlainBlock(op, buffer, openBlockTags);
+        continue;
+      }
+
+      _processInlineTags(op, buffer, openInlineTags);
+      _writeData(op, buffer);
+
+      if (_isMultipleLines(op)) {
+        for (var i = 0; i < (op.data as String).length; i++) {
+          final subOp = Operation.insert('\n', op.attributes);
+          final currentLineStart = nextLineStartPosition;
+          nextLineStartPosition =
+              _handleNewLineLineStyle(subOp, buffer, nextLineStartPosition);
+          int padding = _handleNewLineBlockStyle(
+              subOp, buffer, openInlineTags, openBlockTags, currentLineStart);
+          nextLineStartPosition += padding;
+        }
+      }
+
+      if (_isNewLine(op)) {
+        final currentLineStart = nextLineStartPosition;
+        nextLineStartPosition =
+            _handleNewLineLineStyle(op, buffer, nextLineStartPosition);
+        int padding = _handleNewLineBlockStyle(
+            op, buffer, openInlineTags, openBlockTags, currentLineStart);
+        nextLineStartPosition += padding;
+      }
+    }
+
+    // Close any remaining inline tags
+    for (final attr in openInlineTags) {
+      _writeTag(buffer, attr);
+    }
+
+    // Close any remaining blocks
+    for (var i = 0; i < openBlockTags.length; i++) {
+      final blockTag = openBlockTags[i];
+      // special handling for nested blocs (only nested list at the moment)
+      if (i < openBlockTags.length - 1 &&
+          isNestedList(openBlockTags[i + 1].style, blockTag.style)) {
+        // blockTag.closingPosition = nextLineStartPosition;
+        _writeBlockTag(buffer, blockTag..closingPosition = buffer.length);
+        continue;
+      }
+      _writeBlockTag(buffer, blockTag..closingPosition = buffer.length);
+    }
+    return buffer.toString();
+  }
+
+  bool _hasPlainParagraph(Operation op) {
+    return op.isPlain &&
+        op.data is String &&
+        (op.data as String).contains('\n');
+  }
+
+  void _processInlineTags(
+      Operation op, StringBuffer buffer, List<_HtmlInlineTag> openInlineTags) {
+    final parchmentStyle = ParchmentStyle.fromJson(op.attributes);
+    final Set<ParchmentAttribute> inlineAttributes =
+        Set.from(parchmentStyle.inlineAttributes);
+
+    // Close any tag absent from inline attributes
+    // Closing tags effectively adds the opening tag at the appropriate position
+    // AND adds the closing tag
+    final attributesToRemove = <_HtmlInlineTag>{};
+    for (final attr in openInlineTags) {
+      if (!inlineAttributes.contains(attr.attribute)) {
+        _writeTag(buffer, attr);
+        attributesToRemove.add(attr);
+      }
+    }
+    for (final attr in attributesToRemove) {
+      openInlineTags.remove(attr);
+    }
+
+    // Open any necessary inline attributes
+    for (final attr in inlineAttributes) {
+      if (!openInlineTags.map((e) => e.attribute).contains(attr)) {
+        openInlineTags.insert(0, _HtmlInlineTag(attr, buffer.length));
+      }
+    }
+  }
+
+  bool _isNewLine(Operation op) =>
+      op.data is String && (op.data as String) == '\n';
+
+  bool _isMultipleLines(Operation op) {
+    if (op.data is! String) return false;
+    final text = op.data as String;
+    final regex = RegExp('\n{2,}', multiLine: true);
+    final matches = regex.allMatches(text);
+    return matches.length == 1 && matches.first.group(0) == text;
+  }
+
+  // returns position indicating where following line will start
+  //
+  // Plain block deserve a special treatment as they are the only operations in
+  // which the data string will contain several paragraph.
+  int _handlePlainBlock(
+      Operation op, StringBuffer buffer, List<_HtmlBlockTag> openBlockTags) {
+    assert(_hasPlainParagraph(op));
+    var position = 0;
+    var initialPosition = position;
+
+    if (openBlockTags.isNotEmpty) {
+      final currentBlock = openBlockTags.removeAt(0);
+      position = currentBlock.closingPosition;
+      if (!isPlainIgnoringCSSAndHtmlAttribute(currentBlock.style)) {
+        _writeBlockTag(buffer, currentBlock);
+        position += currentBlock.inducedPadding;
+      }
+    }
+
+    final text = op.data as String;
+    final lines = text.split('\n');
+    for (var i = 0; i < lines.length; i++) {
+      final subOp = Operation.insert(lines[i]);
+      if (i == lines.length - 1) {
+        // Done with set of paragraphs, add last paragraph to block stack.
+        openBlockTags.insert(
+            0, _HtmlBlockTag(ParchmentStyle(), initialPosition, buffer.length));
+        if (lines[i].isNotEmpty) {
+          // Elements that do not belong to a paragraph but to block of next op
+          _writeData(subOp, buffer);
+        }
+        continue;
+      }
+
+      _writeData(subOp, buffer);
+      _writeTag(buffer, _HtmlLineTag(ParchmentStyle(), position));
+      initialPosition = position;
+      position = buffer.length;
+    }
+    assert(openBlockTags.length == 1,
+        'Only one paragraph should be pushed in stack');
+    return position;
+  }
+
+  // used to write html tags of block lines such as <li> or <code>
+  // returns the start position in the buffer of the next line that will be
+  // processed
+  int _handleNewLineLineStyle(
+      Operation op, StringBuffer buffer, int currentLineStart) {
+    final opStyle = ParchmentStyle.fromJson(op.attributes);
+    final newLineTag = _HtmlLineTag(opStyle, currentLineStart);
+    if (newLineTag.style.isNotEmpty) {
+      _writeTag(buffer, newLineTag);
+    }
+    return buffer.length;
+  }
+
+  // used to write html tags of blocks themselves.
+  // returns padding induced by ex-post addition of block tags
+  int _handleNewLineBlockStyle(
+      Operation op,
+      StringBuffer buffer,
+      List<_HtmlInlineTag> openInlineTags,
+      List<_HtmlBlockTag> openBlockTags,
+      int currentLineStart) {
+    final opStyle = ParchmentStyle.fromJson(op.attributes);
+    final startPosition = openBlockTags.firstOrNull?.closingPosition ?? 0;
+
+    var newBlockTag = _HtmlBlockTag(opStyle, startPosition);
+
+    // If no previous style, let caller write surrounding tags
+    if (openBlockTags.isEmpty) {
+      openBlockTags.insert(0, newBlockTag..closingPosition = buffer.length);
+      return 0;
+    }
+
+    if (isSameBlock(openBlockTags[0], newBlockTag)) {
+      openBlockTags[0].closingPosition = buffer.length;
+      return 0;
+    }
+
+    if (isNestedList(openBlockTags[0].style, opStyle)) {
+      openBlockTags.insert(0, _HtmlBlockTag(opStyle, currentLineStart));
+      return 0;
+    }
+
+    // de-nesting
+    if (isNestedList(opStyle, openBlockTags[0].style)) {
+      final currentBlockTag = openBlockTags[0];
+      _writeBlockTag(
+          buffer, currentBlockTag..closingPosition = currentLineStart);
+      openBlockTags.removeAt(0);
+      return currentBlockTag.inducedPadding;
+    }
+
+    if (isPlainIgnoringCSSAndHtmlAttribute(openBlockTags[0].style)) {
+      openBlockTags.removeAt(0);
+      openBlockTags.insert(0, newBlockTag..closingPosition = buffer.length);
+      return 0;
+    }
+
+    // change of block
+    final currentBlockTag = openBlockTags.removeAt(0);
+    _writeBlockTag(buffer, currentBlockTag);
+    // adjust block tag opening with padding induced by previous block tags
+    newBlockTag = newBlockTag.withPadding(currentBlockTag.inducedPadding);
+    newBlockTag.closingPosition = buffer.length;
+    openBlockTags.insert(0, newBlockTag);
+    return newBlockTag.inducedPadding;
+  }
+
+  void _writeTag(StringBuffer buffer, _HtmlTag tag) {
+    final html = buffer.toString();
+    buffer.clear();
+    buffer.writeAll([
+      html.substring(0, tag.openingPosition),
+      tag.openTag,
+      html.substring(tag.openingPosition),
+      tag.closeTag
+    ]);
+  }
+
+  void _writeBlockTag(StringBuffer buffer, _HtmlBlockTag tag) {
+    if (tag.closingPosition == tag.openingPosition) {
+      _writeTag(buffer, tag);
+      return;
+    }
+
+    final html = buffer.toString();
+    buffer.clear();
+    buffer.writeAll([
+      html.substring(0, tag.openingPosition),
+      tag.openTag,
+      html.substring(tag.openingPosition, tag.closingPosition),
+      tag.closeTag,
+      html.substring(tag.closingPosition),
+    ]);
+  }
+
+  void _writeData(Operation op, StringBuffer buffer) {
+    if (op.data is! String) return;
+    var text = op.data as String;
+    if (text.endsWith('\n')) {
+      text = text.substring(0, text.length - 1);
+    }
+    buffer.write(text.replaceAll('\n', ''));
+  }
+}
+
+const _styleAttributePrefix = 'style="';
+const _styleAttributeSuffix = '"';
+
+abstract class _HtmlTag {
+  _HtmlTag(this.openingPosition);
+
+  final int openingPosition;
+
+  String get openTag;
+
+  String get closeTag;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _HtmlTag &&
+          runtimeType == other.runtimeType &&
+          openingPosition == other.openingPosition;
+
+  @override
+  int get hashCode => openingPosition.hashCode;
+}
+
+class _HtmlInlineTag extends _HtmlTag {
+  _HtmlInlineTag(this.attribute, super.openingPosition);
+
+  final ParchmentAttribute attribute;
+
+  @override
+  String get openTag {
+    final key = attribute.key;
+    final value = attribute.value;
+    if (key == ParchmentAttribute.link.key) {
+      return '<${_inlineAttributesParchmentToHtml[key]} href="$value">';
+    }
+    return '<${_inlineAttributesParchmentToHtml[key]}>';
+  }
+
+  @override
+  String get closeTag {
+    return '</${_inlineAttributesParchmentToHtml[attribute.key]}>';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      super == other &&
+          other is _HtmlInlineTag &&
+          runtimeType == other.runtimeType &&
+          attribute == other.attribute;
+
+  @override
+  int get hashCode => super.hashCode ^ attribute.hashCode;
+}
+
+// HTML tags that correspond to line attributes in Parchment
+class _HtmlLineTag extends _HtmlTag {
+  static bool isLineAttribute(ParchmentAttribute attribute) {
+    return attribute.key == ParchmentAttribute.heading.key ||
+        (attribute.key == ParchmentAttribute.block.key &&
+            (attribute.value == ParchmentAttribute.code.value ||
+                attribute.value == ParchmentAttribute.ol.value ||
+                attribute.value == ParchmentAttribute.ul.value ||
+                attribute.value == ParchmentAttribute.cl.value ||
+                attribute.value == ParchmentAttribute.bq.value)) ||
+        attribute.key == ParchmentAttribute.alignment.key ||
+        attribute.key == ParchmentAttribute.direction.key ||
+        attribute.key == ParchmentAttribute.checked.key ||
+        attribute.key == ParchmentAttribute.indent.key;
+  }
+
+  _HtmlLineTag(ParchmentStyle style, super.openingPosition)
+      : style = ParchmentStyle()
+            .putAll(style.lineAttributes.where((e) => isLineAttribute(e)));
+
+  final ParchmentStyle style;
+
+  bool get isPlain =>
+      _ParchmentHtmlEncoder.isPlainIgnoringCSSAndHtmlAttribute(style);
+
+  String? _tagCss;
+
+  String get tagCss {
+    if (_tagCss == null) {
+      var content = alignmentCss;
+      content =
+          content == null ? indentationCss : content += indentationCss ?? '';
+      if (content == null) {
+        _tagCss = '';
+        return _tagCss!;
+      }
+      _tagCss = '$_styleAttributePrefix$content$_styleAttributeSuffix';
+    }
+    return _tagCss!;
+  }
+
+  String? get alignmentCss {
+    var alignment = style.values
+        .firstWhereOrNull((e) => e.key == ParchmentAttribute.alignment.key);
+
+    if (alignment == null) return null;
+
+    const alignmentPrefix = 'text-align:';
+    const alignmentSuffix = ';';
+    if (alignment.value == ParchmentAttribute.alignment.right.value) {
+      return '${alignmentPrefix}right$alignmentSuffix';
+    }
+    if (alignment.value == ParchmentAttribute.alignment.center.value) {
+      return '${alignmentPrefix}center$alignmentSuffix';
+    }
+    if (alignment.value == ParchmentAttribute.alignment.justify.value) {
+      return '${alignmentPrefix}justify$alignmentSuffix';
+    }
+    return null;
+  }
+
+  String? get indentationCss {
+    // For list, indentation is handle with nested lists
+    if (style.values.contains(ParchmentAttribute.ul) ||
+        style.values.contains(ParchmentAttribute.ol)) {
+      return null;
+    }
+    var indentation = style.values
+        .firstWhereOrNull((e) => e.key == ParchmentAttribute.indent.key);
+
+    if (indentation == null) return null;
+    int value = indentation.value;
+    return 'padding-left:${value * _indentWidthInPx}px;';
+  }
+
+  String? _directionAttribute;
+
+  String? get directionAttribute {
+    if (_directionAttribute == null) {
+      var direction = style.values
+          .firstWhereOrNull((e) => e.key == ParchmentAttribute.direction.key);
+
+      if (direction == null) {
+        return _directionAttribute;
+      }
+
+      const directionPrefix = 'dir="';
+      const directionSuffix = '"';
+      if (direction.value == ParchmentAttribute.direction.rtl.value) {
+        _directionAttribute = '${directionPrefix}rtl$directionSuffix';
+      }
+    }
+    return _directionAttribute;
+  }
+
+  @override
+  String get openTag {
+    final css = tagCss.isEmpty ? '' : ' $tagCss';
+    final attribute = directionAttribute != null ? ' $directionAttribute' : '';
+    // If line is plain text
+    if (isPlain) {
+      return '<p$attribute$css>';
+    }
+    String openTag = '';
+    for (final attr in style.values) {
+      if (attr.key == ParchmentAttribute.heading.key) {
+        openTag += '<h${attr.value}$attribute$css>';
+      }
+      if (attr.key == ParchmentAttribute.block.key) {
+        if (attr.value == ParchmentAttribute.bq.value) {
+          openTag += '<blockquote$attribute$css>';
+        }
+        if (attr.value == ParchmentAttribute.code.value) {
+          openTag += '<code>';
+        }
+        if (attr.value == ParchmentAttribute.ol.value) {
+          openTag += '<li$attribute$css>';
+        }
+        if (attr.value == ParchmentAttribute.ul.value) {
+          openTag += '<li$attribute$css>';
+        }
+        if (attr.value == ParchmentAttribute.cl.value) {
+          final checked = style.values
+              .firstWhereOrNull((e) => e.key == ParchmentAttribute.checked.key);
+          final checkedAttribute =
+              checked != null && checked.value ? ' checked' : '';
+          openTag +=
+              '<div class="checklist-item"$attribute$css><input type="checkbox"$checkedAttribute><label>';
+        }
+      }
+    }
+    return openTag;
+  }
+
+  @override
+  String get closeTag {
+    if (isPlain) return '</p>';
+    String openTag = '';
+    for (final attr in style.values) {
+      if (attr.key == ParchmentAttribute.heading.key) {
+        openTag += '</h${attr.value}>';
+      }
+      if (attr.key == ParchmentAttribute.block.key) {
+        if (attr.value == ParchmentAttribute.bq.value) {
+          openTag += '</blockquote>';
+        }
+        if (attr.value == ParchmentAttribute.code.value) {
+          openTag += '</code>';
+        }
+        if (attr.value == ParchmentAttribute.ol.value) {
+          openTag += '</li>';
+        }
+        if (attr.value == ParchmentAttribute.ul.value) {
+          openTag += '</li>';
+        }
+        if (attr.value == ParchmentAttribute.cl.value) {
+          openTag += '</label></div>';
+        }
+      }
+    }
+    return openTag;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      super == other &&
+          other is _HtmlLineTag &&
+          runtimeType == other.runtimeType &&
+          style == other.style;
+
+  @override
+  int get hashCode => super.hashCode ^ style.hashCode;
+}
+
+// HTMLTags that correspond to block attribute in Parchment
+class _HtmlBlockTag extends _HtmlTag {
+  static final supportedBlocks = <String>{
+    ParchmentAttribute.code.value!,
+    ParchmentAttribute.ol.value!,
+    ParchmentAttribute.ul.value!,
+    ParchmentAttribute.cl.value!,
+  };
+
+  static bool isBlockAttribute(ParchmentAttribute attribute) {
+    return attribute.key == ParchmentAttribute.block.key &&
+            supportedBlocks.contains(attribute.value) ||
+        // Needed for nested lists
+        attribute.key == ParchmentAttribute.indent.key;
+  }
+
+  _HtmlBlockTag(ParchmentStyle style, super.openingPosition,
+      [int? closingPosition])
+      : style = ParchmentStyle()
+            .putAll(style.lineAttributes.where((e) => isBlockAttribute(e))),
+        closingPosition = closingPosition ?? openingPosition;
+
+  final ParchmentStyle style;
+  int closingPosition;
+
+  int get inducedPadding => openTag.length + closeTag.length;
+
+  _HtmlBlockTag withPadding(int padding) {
+    return _HtmlBlockTag(
+        style, openingPosition + padding, closingPosition + padding);
+  }
+
+  @override
+  String get openTag {
+    String openTag = '';
+    for (final attr in style.values) {
+      if (attr.key == ParchmentAttribute.block.key) {
+        if (attr.value == ParchmentAttribute.code.value) {
+          openTag += '<pre>';
+        }
+        if (attr.value == ParchmentAttribute.ol.value) {
+          openTag += '<ol>';
+        }
+        if (attr.value == ParchmentAttribute.ul.value) {
+          openTag += '<ul>';
+        }
+        if (attr.value == ParchmentAttribute.cl.value) {
+          openTag += '<div class="checklist">';
+        }
+      }
+    }
+    return openTag;
+  }
+
+  @override
+  String get closeTag {
+    String openTag = '';
+    for (final attr in style.values) {
+      if (attr.key == ParchmentAttribute.block.key) {
+        if (attr.value == ParchmentAttribute.code.value) {
+          openTag += '</pre>';
+        }
+        if (attr.value == ParchmentAttribute.ol.value) {
+          openTag += '</ol>';
+        }
+        if (attr.value == ParchmentAttribute.ul.value) {
+          openTag += '</ul>';
+        }
+        if (attr.value == ParchmentAttribute.cl.value) {
+          openTag += '</div>';
+        }
+      }
+    }
+    return openTag;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      super == other &&
+          other is _HtmlBlockTag &&
+          runtimeType == other.runtimeType &&
+          style == other.style &&
+          closingPosition == other.closingPosition;
+
+  @override
+  int get hashCode =>
+      super.hashCode ^ style.hashCode ^ closingPosition.hashCode;
+}
+
+class _ParchmentHtmlDecoder extends Converter<String, Delta> {
+  const _ParchmentHtmlDecoder();
+
+  @override
+  Delta convert(String input) {
+    Delta delta = Delta();
+    final htmlDocument = parse(input);
+
+    for (var node in htmlDocument.body!.nodes) {
+      delta = delta.concat(_parseNode(node));
+    }
+    _appendNewLineForTopLevelText(delta);
+    return delta;
+  }
+
+  void _appendNewLineForTopLevelText(Delta delta) {
+    if (delta.isEmpty) return delta.insert('\n');
+    if (delta.last.data is! String) return delta.insert('\n');
+    final text = delta.last.data as String;
+    if (!text.endsWith('\n')) return delta.insert('\n');
+    return;
+  }
+
+  bool _isLineNode(html.Node node) {
+    return node is html.Element &&
+        (node.localName == 'p' ||
+            node.localName == 'blockquote' ||
+            node.localName == 'code' ||
+            node.localName == 'li' ||
+            node.localName == 'h1' ||
+            node.localName == 'h2' ||
+            node.localName == 'h3');
+  }
+
+  Delta _parseNode(html.Node node,
+      [ParchmentStyle? inlineStyle, ParchmentStyle? blockStyle]) {
+    inlineStyle ??= ParchmentStyle();
+    blockStyle ??= ParchmentStyle();
+    Delta delta = Delta();
+    if (node is html.Text) {
+      delta.insert(node.text, inlineStyle.toJson());
+      return delta;
+    }
+    if (node is html.Element) {
+      if (node.localName == 'hr') {
+        delta.insert(BlockEmbed.horizontalRule.toJson());
+        return delta;
+      }
+      if (node.localName == 'img') {
+        final src = node.attributes['src'] ?? '';
+        delta.insert(BlockEmbed.image(src).toJson());
+        return delta;
+      }
+      inlineStyle = _updateInlineStyle(node, inlineStyle);
+      blockStyle = _updateBlockStyle(node, blockStyle);
+      if (node.nodes.isNotEmpty) {
+        for (var node in node.nodes) {
+          delta = delta.concat(_parseNode(node, inlineStyle, blockStyle));
+        }
+        if (_isLineNode(node)) {
+          delta.insert('\n', blockStyle.toJson());
+        }
+      }
+    }
+    return delta;
+  }
+
+  ParchmentStyle _updateInlineStyle(
+      html.Element element, ParchmentStyle inlineStyle) {
+    ParchmentStyle updated = inlineStyle;
+    if (element.localName == 'strong') {
+      updated = inlineStyle.put(ParchmentAttribute.bold);
+    } else if (element.localName == 'u') {
+      updated = inlineStyle.put(ParchmentAttribute.underline);
+    } else if (element.localName == 'del') {
+      updated = inlineStyle.put(ParchmentAttribute.strikethrough);
+    } else if (element.localName == 'em') {
+      updated = inlineStyle.put(ParchmentAttribute.italic);
+    } else if (element.localName == 'a') {
+      final link =
+          ParchmentAttribute.link.withValue(element.attributes['href']);
+      updated = inlineStyle.put(link);
+    }
+    return updated;
+  }
+
+  ParchmentStyle _updateBlockStyle(
+      html.Element element, ParchmentStyle blockStyle) {
+    ParchmentStyle updated = blockStyle;
+    if (element.localName == 'h1') {
+      updated = updated.put(ParchmentAttribute.h1);
+    } else if (element.localName == 'h2') {
+      updated = updated.put(ParchmentAttribute.h2);
+    } else if (element.localName == 'h3') {
+      updated = updated.put(ParchmentAttribute.h3);
+    } else if (element.localName == 'blockquote') {
+      updated = updated.put(ParchmentAttribute.bq);
+    } else if (element.localName == 'pre') {
+      updated = updated.put(ParchmentAttribute.code);
+    } else if (element.localName == 'code') {
+      if (!updated.values.contains(ParchmentAttribute.code)) {
+        updated = updated.put(ParchmentAttribute.inlineCode);
+      }
+    } else if (element.localName == 'ol') {
+      if (_hasList(updated)) {
+        final indentLevel = updated.value(ParchmentAttribute.indent) ?? 0;
+        updated =
+            updated.put(ParchmentAttribute.indent.withLevel(indentLevel + 1));
+      }
+      updated = updated.put(ParchmentAttribute.ol);
+    } else if (element.localName == 'ul') {
+      if (_hasList(updated)) {
+        final indentLevel = updated.value(ParchmentAttribute.indent) ?? 0;
+        updated =
+            updated.put(ParchmentAttribute.indent.withLevel(indentLevel + 1));
+      }
+      updated = updated.put(ParchmentAttribute.ul);
+    } else if (element.localName == 'input' &&
+        element.attributes['type'] == 'checkbox') {
+      updated = updated.put(ParchmentAttribute.cl);
+      if (element.attributes.containsKey('checked')) {
+        updated = updated.put(ParchmentAttribute.checked);
+      }
+    }
+
+    // Directionality
+    final dirAttribute = element.attributes['dir'];
+    if (dirAttribute != null && dirAttribute == 'rtl') {
+      updated = updated.put(ParchmentAttribute.rtl);
+    }
+
+    // Styles (currently only alignment)
+    final css = element.attributes['style'];
+    final styles = css?.split(';') ?? [];
+    for (final style in styles) {
+      if (style.startsWith('text-align')) {
+        final sValue = style.split(':')[1];
+        switch (sValue) {
+          case 'right':
+            updated = updated.put(ParchmentAttribute.right);
+            break;
+          case 'center':
+            updated = updated.put(ParchmentAttribute.center);
+            break;
+          case 'justify':
+            updated = updated.put(ParchmentAttribute.justify);
+        }
+        break;
+      }
+    }
+    return updated;
+  }
+
+  bool _hasList(ParchmentStyle blockStyle) {
+    return blockStyle.values.contains(ParchmentAttribute.ol) ||
+        blockStyle.values.contains(ParchmentAttribute.ul);
+  }
+}

--- a/packages/parchment/lib/src/convert/html.dart
+++ b/packages/parchment/lib/src/convert/html.dart
@@ -60,6 +60,7 @@ class _EncoderState {
   StringBuffer buffer = StringBuffer();
   // Stack on inline tags
   final List<_HtmlInlineTag> openInlineTags = [];
+
   // Stack of blocks currently being processed
   // The first element of the stack is the last block that occurred in the
   // operations. When an operation with a different block comes up, the html
@@ -69,7 +70,7 @@ class _EncoderState {
   // Multiple items in the stack means nested blocks are being handled.
   final List<_HtmlBlockTag> openBlockTags = [];
   int nextLineStartPosition = 0;
-  bool isSingleLigne = true;
+  bool isSingleLine = true;
 }
 
 // Inline tags relate directly to ParchmentAttributeScope.inline.
@@ -174,7 +175,7 @@ class _ParchmentHtmlEncoder extends Converter<Delta, String> {
       _processInlineTags(op, buffer, openInlineTags);
       _writeData(op, buffer);
 
-      // when op is serveral new lines, we need to split op into several ops
+      // when op is several new lines, we need to split op into several ops
       // with a single new line
       if (_isMultipleLines(op)) {
         for (var i = 0; i < (op.data as String).length; i++) {
@@ -189,7 +190,7 @@ class _ParchmentHtmlEncoder extends Converter<Delta, String> {
       }
 
       if (_isNewLine(op)) {
-        state.isSingleLigne = false;
+        state.isSingleLine = false;
         final currentLineStart = state.nextLineStartPosition;
         state.nextLineStartPosition =
             _handleNewLineLineStyle(op, buffer, state.nextLineStartPosition);
@@ -220,7 +221,7 @@ class _ParchmentHtmlEncoder extends Converter<Delta, String> {
 
     // remove default paragraph block if single ligne of text
     String result = buffer.toString();
-    if (state.isSingleLigne && result.startsWith('<p>')) {
+    if (state.isSingleLine && result.startsWith('<p>')) {
       return result.substring('<p>'.length, result.length - '</p>'.length);
     }
     return result;
@@ -288,14 +289,14 @@ class _ParchmentHtmlEncoder extends Converter<Delta, String> {
         _writeBlockTag(buffer, currentBlock);
         position += currentBlock.inducedPadding;
       }
-      state.isSingleLigne = false;
+      state.isSingleLine = false;
     }
 
     final text = op.data as String;
     final lines = text.split('\n');
     // several new lines de facto
     if (lines.length > 2) {
-      state.isSingleLigne = false;
+      state.isSingleLine = false;
     }
     for (var i = 0; i < lines.length; i++) {
       final subOp = Operation.insert(lines[i]);
@@ -309,7 +310,7 @@ class _ParchmentHtmlEncoder extends Converter<Delta, String> {
         if (lines[i].isNotEmpty) {
           // Elements that do not belong to a paragraph but to block of next op
           _writeData(subOp, buffer);
-          state.isSingleLigne = false;
+          state.isSingleLine = false;
         }
         continue;
       }

--- a/packages/parchment/lib/src/document/attributes.dart
+++ b/packages/parchment/lib/src/document/attributes.dart
@@ -276,6 +276,14 @@ class ParchmentStyle {
   /// Checks that this style has only one attribute, and returns that attribute.
   ParchmentAttribute get single => _data.values.single;
 
+  /// Returns line-scoped attributes
+  Iterable<ParchmentAttribute> get lineAttributes =>
+      values.where((e) => e.scope == ParchmentAttributeScope.line);
+
+  /// Returns inline-scoped attributes
+  Iterable<ParchmentAttribute> get inlineAttributes =>
+      values.where((e) => e.scope == ParchmentAttributeScope.inline);
+
   /// Returns `true` if attribute with [key] is present in this set.
   ///
   /// Only checks for presence of specified [key] regardless of the associated

--- a/packages/parchment/lib/src/document/attributes.dart
+++ b/packages/parchment/lib/src/document/attributes.dart
@@ -311,6 +311,15 @@ class ParchmentStyle {
     return ParchmentStyle._(result);
   }
 
+  /// Puts [attributes] into this attribute set and returns result as a new set.
+  ParchmentStyle putAll(Iterable<ParchmentAttribute> attributes) {
+    final result = Map<String, ParchmentAttribute>.from(_data);
+    for (final attr in attributes) {
+      result[attr.key] = attr;
+    }
+    return ParchmentStyle._(result);
+  }
+
   /// Merges this attribute set with [attribute] and returns result as a new
   /// attribute set.
   ///

--- a/packages/parchment/lib/src/document/block.dart
+++ b/packages/parchment/lib/src/document/block.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, the Zefyr project authors.  Please see the AUTHORS file
+// Copyright (c) 2018, the Fleather project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 import 'package:quill_delta/quill_delta.dart';

--- a/packages/parchment/pubspec.yaml
+++ b/packages/parchment/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   quill_delta: ^3.0.0-nullsafety.2
   quiver: ^3.1.0
   intl: ^0.17.0
+  html: ^0.15.1
 
 dev_dependencies:
   test: ^1.21.3

--- a/packages/parchment/test/convert/html_test.dart
+++ b/packages/parchment/test/convert/html_test.dart
@@ -8,19 +8,18 @@ void main() {
 
   group('Encode', () {
     group('Basic text', () {
-      test('only new lines', () {
+      test('only two lines', () {
         final doc = ParchmentDocument.fromJson([
           {'insert': '\n\n'},
         ]);
         expect(codec.encode(doc.toDelta()), '<p></p><p></p>');
       });
-
+      
       test('plain text', () {
         final doc = ParchmentDocument.fromJson([
           {'insert': 'Something in the way mmmm...\n'}
         ]);
-        expect(
-            codec.encode(doc.toDelta()), '<p>Something in the way mmmm...</p>');
+        expect(codec.encode(doc.toDelta()), 'Something in the way mmmm...');
       });
 
       test('bold text', () {
@@ -33,7 +32,7 @@ void main() {
           {'insert': ' mmmm...\n'}
         ]);
         expect(codec.encode(doc.toDelta()),
-            '<p>Something <strong>in the way</strong> mmmm...</p>');
+            'Something <strong>in the way</strong> mmmm...');
       });
 
       test('italic + code + underlined + strikethrough text', () {
@@ -53,7 +52,7 @@ void main() {
           {'insert': '\n'}
         ]);
         expect(codec.encode(doc.toDelta()),
-            '<p><del><u>Something </u></del><em>in the way</em><code> mmmm...</code></p>');
+            '<del><u>Something </u></del><em>in the way</em><code> mmmm...</code>');
       });
 
       test('embedded inline attributes text', () {
@@ -73,7 +72,7 @@ void main() {
           {'insert': '\n'}
         ]);
         expect(codec.encode(doc.toDelta()),
-            '<p><u><a href="https://wikipedia.org">Something </a><em>in the way</em> mmmm...</u></p>');
+            '<u><a href="https://wikipedia.org">Something </a><em>in the way</em> mmmm...</u>');
       });
     });
 
@@ -117,25 +116,6 @@ void main() {
 
     group('Blocks', () {
       group('Paragraph', () {
-        test('single', () {
-          final doc = ParchmentDocument.fromJson([
-            {'insert': 'Hello World!\n'}
-          ]);
-          expect(codec.encode(doc.toDelta()), '<p>Hello World!</p>');
-        });
-
-        test('single containing formatting', () {
-          final doc = ParchmentDocument.fromJson([
-            {
-              'insert': 'Hello',
-              'attributes': {'b': true}
-            },
-            {'insert': ' World!\n'}
-          ]);
-          expect(codec.encode(doc.toDelta()),
-              '<p><strong>Hello</strong> World!</p>');
-        });
-
         test('multiple', () {
           final doc = ParchmentDocument.fromJson([
             {'insert': 'Hello World!\nBye World!\n'},
@@ -409,7 +389,7 @@ void main() {
         ]);
 
         expect(codec.encode(doc.toDelta()),
-            '<p><a href="http://fake.link">Hello World!</a></p>');
+            '<a href="http://fake.link">Hello World!</a>');
       });
 
       test('Italic', () {
@@ -422,7 +402,7 @@ void main() {
         ]);
 
         expect(codec.encode(doc.toDelta()),
-            '<p><a href="http://fake.link"><em>Hello World!</em></a></p>');
+            '<a href="http://fake.link"><em>Hello World!</em></a>');
       });
 
       test('In list', () {
@@ -730,6 +710,28 @@ void main() {
             codec.encode(doc.toDelta()),
             '<p>Something in the way...</p>'
             '<blockquote style="padding-left:32px;">Something in the way...</blockquote>');
+      });
+    });
+
+    group('Embeds', () {
+      test('Image', () {
+        final html = '<img src="http://fake.link/image.png">';
+        final doc = ParchmentDocument.fromJson([
+          {'insert': '\n'}
+        ]);
+        doc.insert(0, BlockEmbed.image('http://fake.link/image.png'));
+
+        expect(codec.encode(doc.toDelta()), html);
+      });
+
+      test('Line', () {
+        final html = '<hr>';
+        final doc = ParchmentDocument.fromJson([
+          {'insert': '\n'}
+        ]);
+        doc.insert(0, BlockEmbed.horizontalRule);
+
+        expect(codec.encode(doc.toDelta()), html);
       });
     });
 
@@ -1241,6 +1243,7 @@ void main() {
 
         expect(codec.decode(html), doc.toDelta());
       });
+
       test('Line', () {
         final html = '<hr>';
         final doc = ParchmentDocument.fromJson([

--- a/packages/parchment/test/convert/html_test.dart
+++ b/packages/parchment/test/convert/html_test.dart
@@ -1,0 +1,1408 @@
+import 'package:parchment/parchment.dart';
+import 'package:parchment/src/convert/html.dart';
+import 'package:quill_delta/quill_delta.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final codec = ParchmentHtmlCodec();
+
+  group('Encode', () {
+    group('Basic text', () {
+      test('only new lines', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': '\n\n'},
+        ]);
+        expect(codec.encode(doc.toDelta()), '<p></p><p></p>');
+      });
+
+      test('plain text', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Something in the way mmmm...\n'}
+        ]);
+        expect(
+            codec.encode(doc.toDelta()), '<p>Something in the way mmmm...</p>');
+      });
+
+      test('bold text', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Something '},
+          {
+            'insert': 'in the way',
+            'attributes': {'b': true}
+          },
+          {'insert': ' mmmm...\n'}
+        ]);
+        expect(codec.encode(doc.toDelta()),
+            '<p>Something <strong>in the way</strong> mmmm...</p>');
+      });
+
+      test('italic + code + underlined + strikethrough text', () {
+        final doc = ParchmentDocument.fromJson([
+          {
+            'insert': 'Something ',
+            'attributes': {'s': true, 'u': true}
+          },
+          {
+            'insert': 'in the way',
+            'attributes': {'i': true}
+          },
+          {
+            'insert': ' mmmm...',
+            'attributes': {'c': true}
+          },
+          {'insert': '\n'}
+        ]);
+        expect(codec.encode(doc.toDelta()),
+            '<p><del><u>Something </u></del><em>in the way</em><code> mmmm...</code></p>');
+      });
+
+      test('embedded inline attributes text', () {
+        final doc = ParchmentDocument.fromJson([
+          {
+            'insert': 'Something ',
+            'attributes': {'a': 'https://wikipedia.org', 'u': true}
+          },
+          {
+            'insert': 'in the way',
+            'attributes': {'i': true, 'u': true}
+          },
+          {
+            'insert': ' mmmm...',
+            'attributes': {'u': true}
+          },
+          {'insert': '\n'}
+        ]);
+        expect(codec.encode(doc.toDelta()),
+            '<p><u><a href="https://wikipedia.org">Something </a><em>in the way</em> mmmm...</u></p>');
+      });
+    });
+
+    group('Headings', () {
+      test('1', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'heading': 1}
+          },
+        ]);
+
+        expect(codec.encode(doc.toDelta()), '<h1>Hello World!</h1>');
+      });
+
+      test('2', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'heading': 2}
+          }
+        ]);
+
+        expect(codec.encode(doc.toDelta()), '<h2>Hello World!</h2>');
+      });
+
+      test('3', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'heading': 3}
+          }
+        ]);
+
+        expect(codec.encode(doc.toDelta()), '<h3>Hello World!</h3>');
+      });
+    });
+
+    group('Blocks', () {
+      group('Paragraph', () {
+        test('single', () {
+          final doc = ParchmentDocument.fromJson([
+            {'insert': 'Hello World!\n'}
+          ]);
+          expect(codec.encode(doc.toDelta()), '<p>Hello World!</p>');
+        });
+
+        test('single containing formatting', () {
+          final doc = ParchmentDocument.fromJson([
+            {
+              'insert': 'Hello',
+              'attributes': {'b': true}
+            },
+            {'insert': ' World!\n'}
+          ]);
+          expect(codec.encode(doc.toDelta()),
+              '<p><strong>Hello</strong> World!</p>');
+        });
+
+        test('multiple', () {
+          final doc = ParchmentDocument.fromJson([
+            {'insert': 'Hello World!\nBye World!\n'},
+          ]);
+          expect(codec.encode(doc.toDelta()),
+              '<p>Hello World!</p><p>Bye World!</p>');
+        });
+
+        test('multiple formatted', () {
+          final doc = ParchmentDocument.fromJson([
+            {
+              'insert': 'Hello World!',
+              'attributes': {'b': true}
+            },
+            {'insert': '\n'},
+            {
+              'insert': 'Bye World!',
+              'attributes': {'b': true}
+            },
+            {'insert': '\n'}
+          ]);
+          expect(codec.encode(doc.toDelta()),
+              '<p><strong>Hello World!</strong></p><p><strong>Bye World!</strong></p>');
+        });
+      });
+
+      group('Quote', () {
+        test('Single', () {
+          final doc = ParchmentDocument.fromJson([
+            {'insert': 'Hello World!'},
+            {
+              'insert': '\n',
+              'attributes': {'block': 'quote'}
+            }
+          ]);
+
+          expect(codec.encode(doc.toDelta()),
+              '<blockquote>Hello World!</blockquote>');
+        });
+
+        test('Consecutive with same style', () {
+          final doc = ParchmentDocument.fromJson([
+            {'insert': 'Hello World!'},
+            {
+              'insert': '\n',
+              'attributes': {'block': 'quote'}
+            },
+            {'insert': 'Hello World!'},
+            {
+              'insert': '\n',
+              'attributes': {'block': 'quote'}
+            }
+          ]);
+
+          expect(
+              codec.encode(doc.toDelta()),
+              '<blockquote>Hello World!</blockquote>'
+              '<blockquote>Hello World!</blockquote>');
+        });
+
+        test('Consecutive with different styles', () {
+          final doc = ParchmentDocument.fromJson([
+            {'insert': 'Hello World!'},
+            {
+              'insert': '\n',
+              'attributes': {'block': 'quote'}
+            },
+            {'insert': 'Hello World!'},
+            {
+              'insert': '\n',
+              'attributes': {'block': 'quote', 'alignment': 'center'}
+            }
+          ]);
+
+          expect(
+              codec.encode(doc.toDelta()),
+              '<blockquote>Hello World!</blockquote>'
+              '<blockquote style="text-align:center;">Hello World!</blockquote>');
+        });
+      });
+
+      test('Code', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'void main() {'},
+          {
+            'insert': '\n\n',
+            'attributes': {'block': 'code'}
+          },
+          {'insert': '  print("Hello World!");'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'code'}
+          },
+          {'insert': '}'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'code'}
+          }
+        ]);
+
+        expect(
+          codec.encode(doc.toDelta()),
+          '<pre>'
+          '<code>void main() {</code>'
+          '<code></code>'
+          '<code>  print("Hello World!");</code>'
+          '<code>}</code>'
+          '</pre>',
+        );
+      });
+
+      test('Code then paragraph', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'some code'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'code'}
+          },
+          {'insert': 'Hello world\n'},
+        ]);
+        expect(
+          codec.encode(doc.toDelta()),
+          '<pre><code>some code</code></pre>'
+          '<p>Hello world</p>',
+        );
+      });
+
+      test('Paragraphs then quote', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello world\n'},
+          {
+            'insert': 'Another',
+            'attributes': {'b': true}
+          },
+          {'insert': ' one\n'},
+          {'insert': 'some '},
+          {
+            'insert': 'quote',
+            'attributes': {'b': true}
+          },
+          {
+            'insert': '\n',
+            'attributes': {'block': 'quote'}
+          },
+        ]);
+        expect(
+          codec.encode(doc.toDelta()),
+          '<p>Hello world</p>'
+          '<p><strong>Another</strong> one</p>'
+          '<blockquote>some <strong>quote</strong></blockquote>',
+        );
+      });
+
+      test('Set of blocks', () {
+        final doc = ParchmentDocument.fromJson([
+          {
+            'insert':
+                'Hello world\nHello world\nHello world\nHello world\nsome code'
+          },
+          {
+            'insert': '\n',
+            'attributes': {'block': 'code'}
+          },
+          {'insert': 'Hello world\nsome quote'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'quote'}
+          },
+          {'insert': 'Hello world\n'},
+        ]);
+        expect(
+          codec.encode(doc.toDelta()),
+          '<p>Hello world</p>'
+          '<p>Hello world</p>'
+          '<p>Hello world</p>'
+          '<p>Hello world</p>'
+          '<pre><code>some code</code></pre>'
+          '<p>Hello world</p>'
+          '<blockquote>some quote</blockquote>'
+          '<p>Hello world</p>',
+        );
+      });
+
+      test('Ordered list', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          },
+          {'insert': 'This is Fleather!'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          }
+        ]);
+
+        expect(codec.encode(doc.toDelta()),
+            '<ol><li>Hello World!</li><li>This is Fleather!</li></ol>');
+      });
+
+      test('List with bold', () {
+        final doc = ParchmentDocument.fromJson([
+          {
+            'insert': 'Hello World!',
+            'attributes': {'b': true}
+          },
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          },
+          {'insert': 'This is Fleather!'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          }
+        ]);
+
+        expect(codec.encode(doc.toDelta()),
+            '<ol><li><strong>Hello World!</strong></li><li>This is Fleather!</li></ol>');
+      });
+
+      test('Unordered list', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul'}
+          },
+          {'insert': 'This is Fleather!'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul'}
+          }
+        ]);
+
+        expect(codec.encode(doc.toDelta()),
+            '<ul><li>Hello World!</li><li>This is Fleather!</li></ul>');
+      });
+      test('Checklist', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'cl', 'checked': true}
+          },
+          {'insert': 'item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'cl'}
+          }
+        ]);
+
+        expect(
+            codec.encode(doc.toDelta()),
+            '<div class="checklist">'
+            '<div class="checklist-item"><input type="checkbox" checked><label>item</label></div>'
+            '<div class="checklist-item"><input type="checkbox"><label>item</label></div>'
+            '</div>');
+      });
+    });
+
+    group('Links', () {
+      test('Plain', () {
+        final doc = ParchmentDocument.fromJson([
+          {
+            'insert': 'Hello World!',
+            'attributes': {'a': 'http://fake.link'},
+          },
+          {'insert': '\n'}
+        ]);
+
+        expect(codec.encode(doc.toDelta()),
+            '<p><a href="http://fake.link">Hello World!</a></p>');
+      });
+
+      test('Italic', () {
+        final doc = ParchmentDocument.fromJson([
+          {
+            'insert': 'Hello World!',
+            'attributes': {'a': 'http://fake.link', 'i': true},
+          },
+          {'insert': '\n'}
+        ]);
+
+        expect(codec.encode(doc.toDelta()),
+            '<p><a href="http://fake.link"><em>Hello World!</em></a></p>');
+      });
+
+      test('In list', () {
+        final doc = ParchmentDocument.fromJson([
+          {
+            'insert': 'Hello World!',
+            'attributes': {'a': 'http://fake.link'},
+          },
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul'},
+          }
+        ]);
+
+        expect(codec.encode(doc.toDelta()),
+            '<ul><li><a href="http://fake.link">Hello World!</a></li></ul>');
+      });
+    });
+
+    group('Direction', () {
+      test('RTL', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello World!'},
+          {'insert': '\n'},
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'direction': 'rtl'}
+          }
+        ]);
+
+        expect(codec.encode(doc.toDelta()),
+            '<p>Hello World!</p><p dir="rtl">Hello World!</p>');
+      });
+
+      test('In list', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'},
+          },
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {
+              'direction': 'rtl',
+              'block': 'ol',
+              'alignment': 'center'
+            },
+          },
+        ]);
+
+        expect(codec.encode(doc.toDelta()),
+            '<ol><li>Hello World!</li><li dir="rtl" style="text-align:center;">Hello World!</li></ol>');
+      });
+    });
+
+    group('Alignment', () {
+      test('center', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'alignment': 'center'}
+          }
+        ]);
+        expect(codec.encode(doc.toDelta()),
+            '<p style="text-align:center;">Hello World!</p>');
+      });
+
+      test('all paragraph alignments', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'alignment': null}
+          },
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'alignment': 'right'}
+          },
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'alignment': 'center'}
+          },
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'alignment': 'justify'}
+          }
+        ]);
+        expect(
+          codec.encode(doc.toDelta()),
+          '<p>Hello World!</p>'
+          '<p style="text-align:right;">Hello World!</p>'
+          '<p style="text-align:center;">Hello World!</p>'
+          '<p style="text-align:justify;">Hello World!</p>',
+        );
+      });
+
+      test('all list alignments', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'alignment': null}
+          },
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'alignment': 'right'}
+          },
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'alignment': 'center'}
+          },
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'alignment': 'justify'}
+          }
+        ]);
+        expect(
+            codec.encode(doc.toDelta()),
+            '<ol>'
+            '<li>Hello World!</li>'
+            '<li style="text-align:right;">Hello World!</li>'
+            '<li style="text-align:center;">Hello World!</li>'
+            '<li style="text-align:justify;">Hello World!</li>'
+            '</ol>');
+      });
+    });
+
+    group('Indentation', () {
+      test('Nested lists - 3 levels', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          },
+          {'insert': 'sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul', 'indent': 1}
+          },
+          {'insert': 'sub-sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'indent': 2}
+          },
+          {'insert': 'sub-sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'indent': 2}
+          },
+          {'insert': 'sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul', 'indent': 1}
+          },
+          {'insert': 'item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          },
+        ]);
+
+        expect(
+            codec.encode(doc.toDelta()),
+            '<ol>'
+            '<li>item</li>'
+            '<ul>'
+            '<li>sub-item</li>'
+            '<ol>'
+            '<li>sub-sub-item</li>'
+            '<li>sub-sub-item</li>'
+            '</ol>'
+            '<li>sub-item</li>'
+            '</ul>'
+            '<li>item</li>'
+            '</ol>');
+      });
+
+      test('Multiple nested lists - 4 levels', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          },
+          {'insert': 'sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul', 'indent': 1}
+          },
+          {'insert': 'sub-sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'indent': 2}
+          },
+          {'insert': 'sub-sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'indent': 2}
+          },
+          {'insert': 'sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul', 'indent': 1}
+          },
+          {'insert': 'item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          },
+          {'insert': 'sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul', 'indent': 1}
+          },
+          {'insert': 'sub-sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul', 'indent': 2}
+          },
+          {'insert': 'sub-sub-sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'indent': 3}
+          },
+          {'insert': 'sub-sub-sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'indent': 3}
+          },
+          {'insert': 'sub-sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul', 'indent': 2}
+          },
+          {'insert': 'sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul', 'indent': 1}
+          },
+        ]);
+
+        expect(
+          codec.encode(doc.toDelta()),
+          '<ol>'
+          '<li>item</li>'
+          '<ul>'
+          '<li>sub-item</li>'
+          '<ol>'
+          '<li>sub-sub-item</li>'
+          '<li>sub-sub-item</li>'
+          '</ol>'
+          '<li>sub-item</li>'
+          '</ul>'
+          '<li>item</li>'
+          '<ul>'
+          '<li>sub-item</li>'
+          '<ul>'
+          '<li>sub-sub-item</li>'
+          '<ol>'
+          '<li>sub-sub-sub-item</li>'
+          '<li>sub-sub-sub-item</li>'
+          '</ol>'
+          '<li>sub-sub-item</li>'
+          '</ul>'
+          '<li>sub-item</li>'
+          '</ul>'
+          '</ol>',
+        );
+      });
+
+      test('Paragraph with margin', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Something in the way...\nSomething in the way...'},
+          {
+            'insert': '\n',
+            'attributes': {'indent': 1}
+          },
+        ]);
+        expect(
+            codec.encode(doc.toDelta()),
+            '<p>Something in the way...</p>'
+            '<p style="padding-left:32px;">Something in the way...</p>');
+      });
+
+      test('Quotes with margin', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Something in the way...\nSomething in the way...'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'quote', 'indent': 1}
+          },
+        ]);
+        expect(
+            codec.encode(doc.toDelta()),
+            '<p>Something in the way...</p>'
+            '<blockquote style="padding-left:32px;">Something in the way...</blockquote>');
+      });
+    });
+
+    test('Multiple styles', () {
+      final act = codec.encode(delta);
+      expect(act, htmlDoc);
+    });
+  });
+
+  group('Decode', () {
+    group('Basic text', () {
+      test('Plain paragraph', () {
+        final html = 'Hello World!';
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello World!\n'}
+        ]);
+
+        expect(codec.decode(html), doc.toDelta());
+      });
+
+      test('Bold paragraph', () {
+        final html = '<strong>Hello World!</strong>';
+        final doc = ParchmentDocument.fromJson([
+          {
+            'insert': 'Hello World!',
+            'attributes': {'b': true}
+          },
+          {'insert': '\n'},
+        ]);
+
+        expect(codec.decode(html), doc.toDelta());
+      });
+
+      test('Underline paragraph', () {
+        final html = '<u>Hello World!</u>';
+        final doc = ParchmentDocument.fromJson([
+          {
+            'insert': 'Hello World!',
+            'attributes': {'u': true}
+          },
+          {'insert': '\n'},
+        ]);
+
+        expect(codec.decode(html), doc.toDelta());
+      });
+
+      test('Strikethrough paragraph', () {
+        final html = '<del>Hello World!</del>';
+        final doc = ParchmentDocument.fromJson([
+          {
+            'insert': 'Hello World!',
+            'attributes': {'s': true}
+          },
+          {'insert': '\n'},
+        ]);
+
+        expect(codec.decode(html), doc.toDelta());
+      });
+
+      test('Italic paragraph', () {
+        final html = '<em>Hello World!</em>';
+        final doc = ParchmentDocument.fromJson([
+          {
+            'insert': 'Hello World!',
+            'attributes': {'i': true}
+          },
+          {'insert': '\n'},
+        ]);
+
+        expect(codec.decode(html), doc.toDelta());
+      });
+
+      test('Bold and Italic paragraph', () {
+        final html = '<em><strong>Hello World!</em></strong>';
+        final doc = ParchmentDocument.fromJson([
+          {
+            'insert': 'Hello World!',
+            'attributes': {'i': true, 'b': true}
+          },
+          {'insert': '\n'},
+        ]);
+
+        expect(codec.decode(html), doc.toDelta());
+      });
+
+      test('embedded inline attributes text', () {
+        final html =
+            '<p><u><a href="https://wikipedia.org">Something </a><em>in the way</em> mmmm...</u></p>';
+        final doc = ParchmentDocument.fromJson([
+          {
+            'insert': 'Something ',
+            'attributes': {'a': 'https://wikipedia.org', 'u': true}
+          },
+          {
+            'insert': 'in the way',
+            'attributes': {'i': true, 'u': true}
+          },
+          {
+            'insert': ' mmmm...',
+            'attributes': {'u': true}
+          },
+          {'insert': '\n'}
+        ]);
+        expect(codec.decode(html), doc.toDelta());
+      });
+    });
+
+    group('Headings', () {
+      test('1', () {
+        final html = '<h1>Hello World!</h1>';
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'heading': 1}
+          },
+        ]);
+
+        expect(codec.decode(html), doc.toDelta());
+      });
+
+      test('2', () {
+        final html = '<h2>Hello World!</h2>';
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'heading': 2}
+          }
+        ]);
+
+        expect(codec.decode(html), doc.toDelta());
+      });
+
+      test('3', () {
+        final html = '<h3>Hello World!</h3>';
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'heading': 3}
+          }
+        ]);
+
+        expect(codec.decode(html), doc.toDelta());
+      });
+    });
+
+    group('Blocks', () {
+      group('Paragraph', () {
+        test('simple', () {
+          final html = '<p>Hello World!</p>';
+          final doc = ParchmentDocument.fromJson([
+            {
+              'insert': 'Hello World!\n',
+            }
+          ]);
+          expect(codec.decode(html), doc.toDelta());
+        });
+
+        test('Paragraph with link', () {
+          final html =
+              '<p>Hello World!<a href="http://fake.link">Hello World!</a> Another hello world!</p>';
+          final doc = ParchmentDocument.fromJson([
+            {
+              'insert': 'Hello World!',
+            },
+            {
+              'insert': 'Hello World!',
+              'attributes': {'a': 'http://fake.link'},
+            },
+            {
+              'insert': ' Another hello world!\n',
+            }
+          ]);
+
+          expect(codec.decode(html), doc.toDelta());
+        });
+
+        test('Multiples paragraphs', () {
+          final html =
+              '<p>Hello World!<a href="http://fake.link">Hello World!</a> Another hello world!</p><p>Hello World!<a href="http://fake.link">Hello World!</a> Another hello world!</p>';
+          final doc = ParchmentDocument.fromJson([
+            {
+              'insert': 'Hello World!',
+            },
+            {
+              'insert': 'Hello World!',
+              'attributes': {'a': 'http://fake.link'},
+            },
+            {
+              'insert': ' Another hello world!\n',
+            },
+            {
+              'insert': 'Hello World!',
+            },
+            {
+              'insert': 'Hello World!',
+              'attributes': {'a': 'http://fake.link'},
+            },
+            {
+              'insert': ' Another hello world!\n',
+            }
+          ]);
+
+          expect(codec.decode(html), doc.toDelta());
+        });
+      });
+
+      test('Quote', () {
+        final html = '<blockquote>Hello World!</blockquote><br><br>';
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'quote'}
+          }
+        ]);
+
+        expect(codec.decode(html), doc.toDelta());
+      });
+      test('Code', () {
+        final html = '<pre>'
+            '<code>void main() {</code>'
+            '<code>  print("Hello world!");</code>'
+            '<code>}</code>'
+            '</pre>';
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'void main() {'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'code'}
+          },
+          {'insert': '  print("Hello world!");'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'code'}
+          },
+          {'insert': '}'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'code'}
+          }
+        ]);
+
+        expect(codec.decode(html), doc.toDelta());
+      });
+
+      test('Code then paragraph', () {
+        final html = '<pre><code>some code</code></pre>'
+            '<p>Hello world</p>';
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'some code'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'code'}
+          },
+          {'insert': 'Hello world\n'},
+        ]);
+        expect(codec.decode(html), doc.toDelta());
+      });
+
+      test('Paragraphs then quote', () {
+        final html = '<p>Hello world</p>'
+            '<p><strong>Another</strong> one</p>'
+            '<blockquote>some <strong>quote</strong></blockquote>';
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello world\n'},
+          {
+            'insert': 'Another',
+            'attributes': {'b': true}
+          },
+          {'insert': ' one\n'},
+          {'insert': 'some '},
+          {
+            'insert': 'quote',
+            'attributes': {'b': true}
+          },
+          {
+            'insert': '\n',
+            'attributes': {'block': 'quote'}
+          },
+        ]);
+        expect(codec.decode(html), doc.toDelta());
+      });
+
+      test('Ordered list', () {
+        final html = '<ol><li>an item</li><li>another item</li></ol>';
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'an item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          },
+          {'insert': 'another item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          }
+        ]);
+
+        expect(codec.decode(html), doc.toDelta());
+      });
+      test('List with bold', () {
+        final html = '<ol><li><strong>Hello World!</strong></li></ol><br><br>';
+        final doc = ParchmentDocument.fromJson([
+          {
+            'insert': 'Hello World!',
+            'attributes': {'b': true}
+          },
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          }
+        ]);
+
+        expect(codec.decode(html), doc.toDelta());
+      });
+      test('Unordered list', () {
+        final html =
+            '<ul><li>Hello World!</li><li>Hello World!</li></ul><br><br>';
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul'}
+          },
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul'}
+          }
+        ]);
+
+        expect(codec.decode(html), doc.toDelta());
+      });
+    });
+
+    group('Alignment', () {
+      test('center', () {
+        final html = '<p style="text-align:center;">Hello World!</p>';
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'alignment': 'center'}
+          }
+        ]);
+        expect(codec.decode(html), doc.toDelta());
+      });
+
+      test('all paragraph alignments', () {
+        final html = '<p>Hello World!</p>'
+            '<p style="text-align:right;">Hello World!</p>'
+            '<p style="text-align:center;">Hello World!</p>'
+            '<p style="text-align:justify;">Hello World!</p>';
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello World!\nHello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'alignment': 'right'}
+          },
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'alignment': 'center'}
+          },
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'alignment': 'justify'}
+          }
+        ]);
+        expect(codec.decode(html), doc.toDelta());
+      });
+
+      test('all list alignments', () {
+        final html = '<ol>'
+            '<li>Hello World!</li>'
+            '<li style="text-align:right;">Hello World!</li>'
+            '<li style="text-align:center;">Hello World!</li>'
+            '<li style="text-align:justify;">Hello World!</li>'
+            '</ol>';
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          },
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'alignment': 'right'}
+          },
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'alignment': 'center'}
+          },
+          {'insert': 'Hello World!'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'alignment': 'justify'}
+          }
+        ]);
+        expect(codec.decode(html), doc.toDelta());
+      });
+    });
+
+    group('Indentation', () {
+      test('Nested lists', () {
+        final html = '<ol>'
+            '<li>item</li>'
+            '<ul>'
+            '<li>sub-item</li>'
+            '<ol>'
+            '<li>sub-sub-item</li>'
+            '<li>sub-sub-item</li>'
+            '</ol>'
+            '<li>sub-item</li>'
+            '</ul>'
+            '<li>item</li>'
+            '<ul>'
+            '<li>sub-item</li>'
+            '<ul>'
+            '<li>sub-sub-item</li>'
+            '<ol>'
+            '<li>sub-sub-sub-item</li>'
+            '<li>sub-sub-sub-item</li>'
+            '</ol>'
+            '<li>sub-sub-item</li>'
+            '</ul>'
+            '<li>sub-item</li>'
+            '</ul>'
+            '</ol>';
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          },
+          {'insert': 'sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul', 'indent': 1}
+          },
+          {'insert': 'sub-sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'indent': 2}
+          },
+          {'insert': 'sub-sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'indent': 2}
+          },
+          {'insert': 'sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul', 'indent': 1}
+          },
+          {'insert': 'item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          },
+          {'insert': 'sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul', 'indent': 1}
+          },
+          {'insert': 'sub-sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul', 'indent': 2}
+          },
+          {'insert': 'sub-sub-sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'indent': 3}
+          },
+          {'insert': 'sub-sub-sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'indent': 3}
+          },
+          {'insert': 'sub-sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul', 'indent': 2}
+          },
+          {'insert': 'sub-item'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul', 'indent': 1}
+          },
+        ]);
+        expect(codec.decode(html), doc.toDelta());
+      });
+    });
+
+    group('Embeds', () {
+      test('Image', () {
+        final html = '<img src="http://fake.link/image.png">';
+        final doc = ParchmentDocument.fromJson([
+          {'insert': '\n'}
+        ]);
+        doc.insert(0, BlockEmbed.image('http://fake.link/image.png'));
+
+        expect(codec.decode(html), doc.toDelta());
+      });
+      test('Line', () {
+        final html = '<hr>';
+        final doc = ParchmentDocument.fromJson([
+          {'insert': '\n'}
+        ]);
+        doc.insert(0, BlockEmbed.horizontalRule);
+
+        expect(codec.decode(html), doc.toDelta());
+      });
+    });
+
+    group('Links', () {
+      test('Plain', () {
+        final html = '<a href="http://fake.link">Hello World!</a><br><br>';
+        final doc = ParchmentDocument.fromJson([
+          {
+            'insert': 'Hello World!',
+            'attributes': {'a': 'http://fake.link'},
+          },
+          {'insert': '\n'}
+        ]);
+
+        expect(codec.decode(html), doc.toDelta());
+      });
+
+      test('Italic', () {
+        final html =
+            '<a href="http://fake.link"><em>Hello World!</em></a><br><br>';
+        final doc = ParchmentDocument.fromJson([
+          {
+            'insert': 'Hello World!',
+            'attributes': {'a': 'http://fake.link', 'i': true},
+          },
+          {'insert': '\n'}
+        ]);
+
+        expect(codec.decode(html), doc.toDelta());
+      });
+
+      test('In list', () {
+        final html =
+            '<ul><li><a href="http://fake.link">Hello World!</a></li></ul>';
+        final doc = ParchmentDocument.fromJson([
+          {
+            'insert': 'Hello World!',
+            'attributes': {'a': 'http://fake.link'},
+          },
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ul'},
+          }
+        ]);
+
+        expect(codec.decode(html), doc.toDelta());
+      });
+    });
+  }, skip: false);
+}
+
+final doc = [
+  {'insert': 'Fleather'},
+  {
+    'insert': '\n',
+    'attributes': {'heading': 1}
+  },
+  {
+    'insert': 'Soft and gentle rich text editing for Flutter applications.',
+    'attributes': {'i': true}
+  },
+  {'insert': '\nFleather is an '},
+  {
+    'insert': 'early preview',
+    'attributes': {'b': true}
+  },
+  {'insert': ' open source library.\nDocumentation'},
+  {
+    'insert': '\n',
+    'attributes': {'heading': 3}
+  },
+  {'insert': 'Quick Start'},
+  {
+    'insert': '\n',
+    'attributes': {'block': 'ul'}
+  },
+  {'insert': 'Data format and Document Model'},
+  {
+    'insert': '\n',
+    'attributes': {'block': 'ul'}
+  },
+  {'insert': 'Style attributes'},
+  {
+    'insert': '\n',
+    'attributes': {'block': 'ul'}
+  },
+  {'insert': 'Heuristic rules'},
+  {
+    'insert': '\n',
+    'attributes': {'block': 'ul'}
+  },
+  {'insert': 'Clean and modern look'},
+  {
+    'insert': '\n',
+    'attributes': {'heading': 2}
+  },
+  {'insert': 'Fleather’s rich text editor is built with '},
+  {
+    'insert': 'simplicity and flexibility',
+    'attributes': {'i': true}
+  },
+  {
+    'insert':
+        ' in mind. It provides clean interface for distraction-free editing. Think '
+  },
+  {
+    'insert': 'Medium.com',
+    'attributes': {'c': true}
+  },
+  // {'insert': '-like experience.\n'},
+  {'insert': '-like experience.\nimport ‘package:flutter/material.dart’;'},
+  {
+    'insert': '\n',
+    'attributes': {'block': 'code'}
+  },
+  {'insert': 'import ‘package:parchment/parchment.dart’;'},
+  {
+    'insert': '\n\n',
+    'attributes': {'block': 'code'}
+  },
+  {'insert': 'void main() {'},
+  {
+    'insert': '\n',
+    'attributes': {'block': 'code'}
+  },
+  {'insert': ' print(“Hello world!”);'},
+  {
+    'insert': '\n',
+    'attributes': {'block': 'code'}
+  },
+  {'insert': '}'},
+  {
+    'insert': '\n',
+    'attributes': {'block': 'code'}
+  }
+];
+final delta = Delta.fromJson(doc);
+final htmlDoc = '<h1>Fleather</h1>'
+    '<p><em>Soft and gentle rich text editing for Flutter applications.</em></p>'
+    '<p>Fleather is an <strong>early preview</strong> open source library.</p>'
+    '<h3>Documentation</h3>'
+    '<ul>'
+    '<li>Quick Start</li>'
+    '<li>Data format and Document Model</li>'
+    '<li>Style attributes</li>'
+    '<li>Heuristic rules</li>'
+    '</ul>'
+    '<h2>Clean and modern look</h2>'
+    '<p>Fleather’s rich text editor is built with <em>simplicity and flexibility</em> in mind. It provides clean interface for distraction-free editing. Think <code>Medium.com</code>-like experience.</p>'
+    '<pre>'
+    '<code>import ‘package:flutter/material.dart’;</code>'
+    '<code>import ‘package:parchment/parchment.dart’;</code>'
+    '<code></code>'
+    '<code>void main() {</code>'
+    '<code> print(“Hello world!”);</code>'
+    '<code>}</code>'
+    '</pre>';

--- a/packages/parchment/test/convert/html_test.dart
+++ b/packages/parchment/test/convert/html_test.dart
@@ -14,7 +14,7 @@ void main() {
         ]);
         expect(codec.encode(doc.toDelta()), '<p></p><p></p>');
       });
-      
+
       test('plain text', () {
         final doc = ParchmentDocument.fromJson([
           {'insert': 'Something in the way mmmm...\n'}


### PR DESCRIPTION
This PR is necessary to close #56.
Parchment can now convert a document `Delta` to `HTML` and convert `HTML` to `Delta`.

### Encoding :
- Checklists give the following result:
```html 
<div class="checklist">
  <div class="checklist-item><input type="checkbox" checked><label>item 1</label></div>
  <div class="checklist-item><input type="checkbox"><label>item 2</label></div>
</div>
```
- Indentations on blocks that are not lists give the following
```html
<p style="padding-left:32px">indented text</p>
```
- Directionality is converted as follows:
```html
<p dir="rtl">العربية</p>
```
- Single paragraphs (plain blocks) are encoded to simple text (no `<p>`)
```html
A single <strong>paragraph</strong>
```

### Decoding :
- Checklists are not supported as there are numerous ways to layout `<input>`s
- Indentations in blocks that are not lists are not supported due to the numerous way of materializing in `HTML`
- `<br>`'s are ignored as they do not map to any attribute in Fleather (new line lead necessarily to a new block)