### PR TITLE
Fixes for the new ParchmentHtmlEncoder

### DIFF
--- a/packages/parchment/lib/convert.dart
+++ b/packages/parchment/lib/convert.dart
@@ -6,8 +6,13 @@
 library parchment.convert;
 
 import 'src/convert/markdown.dart';
+import 'src/convert/html.dart';
 
 export 'src/convert/markdown.dart';
+export 'src/convert/html.dart';
 
 /// Markdown codec for Parchment documents.
 const ParchmentMarkdownCodec parchmentMarkdown = ParchmentMarkdownCodec();
+
+/// HTML codec for Parchment documents.
+const ParchmentHtmlCodec parchmentHtml = ParchmentHtmlCodec();

--- a/packages/parchment/lib/src/convert/html.dart
+++ b/packages/parchment/lib/src/convert/html.dart
@@ -641,8 +641,7 @@ class _HtmlLineTag extends _HtmlTag {
           openTag += '<blockquote$attribute$css>';
         }
         if (attr.value == ParchmentAttribute.code.value) {
-          // We are in a <pre> block at this point.
-          openTag += '<code>';
+          // We are in a <pre><code> block at this point, so no need for an additional <code>.
         }
         if (attr.value == ParchmentAttribute.ol.value) {
           openTag += '<li$attribute$css>';
@@ -678,8 +677,8 @@ class _HtmlLineTag extends _HtmlTag {
           closeTag += '</blockquote>';
         }
         if (attr.value == ParchmentAttribute.code.value) {
-          // We are in a <pre> block. We need to add a newline to display as a line break.
-          closeTag += '</code>\n';
+          // We are in a <pre><code> block. We need to add a newline to display as a line break.
+          closeTag += '\n';
         }
         if (attr.value == ParchmentAttribute.ol.value) {
           closeTag += '</li>';
@@ -745,7 +744,7 @@ class _HtmlBlockTag extends _HtmlTag {
     for (final attr in style.values) {
       if (attr.key == ParchmentAttribute.block.key) {
         if (attr.value == ParchmentAttribute.code.value) {
-          openTag += '<pre>';
+          openTag += '<pre><code>';
         }
         if (attr.value == ParchmentAttribute.ol.value) {
           openTag += '<ol>';
@@ -767,7 +766,7 @@ class _HtmlBlockTag extends _HtmlTag {
     for (final attr in style.values) {
       if (attr.key == ParchmentAttribute.block.key) {
         if (attr.value == ParchmentAttribute.code.value) {
-          openTag += '</pre>';
+          openTag += '</code></pre>';
         }
         if (attr.value == ParchmentAttribute.ol.value) {
           openTag += '</ol>';

--- a/packages/parchment/lib/src/convert/html.dart
+++ b/packages/parchment/lib/src/convert/html.dart
@@ -106,6 +106,10 @@ class _ParchmentHtmlEncoder extends Converter<Delta, String> {
     return true;
   }
 
+  static bool isChecklist(ParchmentStyle style) {
+    return style.values.contains(ParchmentAttribute.cl);
+  }
+
   // For lists and block code, new lines do not necessarily mean a new block
   static bool isSameBlock(_HtmlBlockTag previous, _HtmlBlockTag current) {
     final p = previous.style.values;
@@ -235,7 +239,10 @@ class _ParchmentHtmlEncoder extends Converter<Delta, String> {
         position += blockTag.inducedPadding;
       }
 
-      blockTag.closingPosition = buffer.length;
+      if (!isChecklist(blockTag.style)) {
+        blockTag.closingPosition = buffer.length;
+      }
+
       _writeBlockTag(buffer, blockTag);
     }
 

--- a/packages/parchment/lib/src/convert/html.dart
+++ b/packages/parchment/lib/src/convert/html.dart
@@ -321,8 +321,9 @@ class _ParchmentHtmlEncoder extends Converter<Delta, String> {
       position = buffer.length;
     }
 
-    assert(openBlockTags.length <= 1,
-        'At most one paragraph should be pushed in stack');
+    // This assert cannot exist otherwise nested lists won't work.
+    // assert(openBlockTags.length <= 1,
+    //     'At most one paragraph should be pushed in stack');
     state.nextLineStartPosition = position;
   }
 

--- a/packages/parchment/lib/src/convert/html.dart
+++ b/packages/parchment/lib/src/convert/html.dart
@@ -31,7 +31,7 @@ const _indentWidthInPx = 32;
 /// - default -> <p>
 /// - heading X -> <hX>
 /// - bq -> <blockquote>
-/// - code -> <pre>
+/// - code -> <pre><code>
 /// - ol -> <ol><li>
 /// - ul -> <ul><li>
 /// - cl -> <div class="checklist">
@@ -641,7 +641,8 @@ class _HtmlLineTag extends _HtmlTag {
           openTag += '<blockquote$attribute$css>';
         }
         if (attr.value == ParchmentAttribute.code.value) {
-          // We are in a <pre> block at this point. No <code> tag is needed.
+          // We are in a <pre> block at this point.
+          openTag += '<code>';
         }
         if (attr.value == ParchmentAttribute.ol.value) {
           openTag += '<li$attribute$css>';
@@ -677,8 +678,8 @@ class _HtmlLineTag extends _HtmlTag {
           closeTag += '</blockquote>';
         }
         if (attr.value == ParchmentAttribute.code.value) {
-          // We are in a <pre> block. We only need to add a newline to display as a line break.
-          closeTag += '\n';
+          // We are in a <pre> block. We need to add a newline to display as a line break.
+          closeTag += '</code>\n';
         }
         if (attr.value == ParchmentAttribute.ol.value) {
           closeTag += '</li>';

--- a/packages/parchment/test/convert/html_test.dart
+++ b/packages/parchment/test/convert/html_test.dart
@@ -109,8 +109,23 @@ void main() {
           },
           {'insert': '\n'}
         ]);
-        expect(codec.encode(doc.toDelta()),
-            '<p>Line 1</p><p><br></p><p><br></p><p><br></p><p>Line 2</p><p>Line3</p><p>not blank1</p><p>not blank2</p><p>not blank3</p><p>Line 4</p><p><strong>Line 5</strong></p><p> <br></p><p><br></p><p><br></p><p><strong>Line 6</strong></p>');
+        expect(
+            codec.encode(doc.toDelta()),
+            '<p>Line 1</p>'
+            '<p><br></p>'
+            '<p><br></p>'
+            '<p><br></p>'
+            '<p>Line 2</p>'
+            '<p>Line3</p>'
+            '<p>not blank1</p>'
+            '<p>not blank2</p>'
+            '<p>not blank3</p>'
+            '<p>Line 4</p>'
+            '<p><strong>Line 5</strong></p>'
+            '<p> <br></p>'
+            '<p><br></p>'
+            '<p><br></p>'
+            '<p><strong>Line 6</strong></p>');
       });
 
       test('several styled lines in a row', () {
@@ -142,8 +157,13 @@ void main() {
           },
           {'insert': '\n'},
         ]);
-        expect(codec.encode(doc.toDelta()),
-            '<p><strong>Bold</strong></p><p><em>Italic</em></p><p><strong>Bold</strong></p><p><em>Italic</em></p><p><strong>Bold</strong></p>');
+        expect(
+            codec.encode(doc.toDelta()),
+            '<p><strong>Bold</strong></p>'
+            '<p><em>Italic</em></p>'
+            '<p><strong>Bold</strong></p>'
+            '<p><em>Italic</em></p>'
+            '<p><strong>Bold</strong></p>');
       });
     });
 
@@ -467,8 +487,13 @@ void main() {
           {'insert': '.\n'}
         ]);
 
-        expect(codec.encode(doc.toDelta()),
-            '<div class="checklist"><div class="checklist-item"><input type="checkbox" checked disabled><label>&nbsp;Check - 1</label></div><div class="checklist-item"><input type="checkbox" disabled><label>&nbsp;Check - 2</label></div></div><p>A link to a <a href="https://example.com">site</a>.</p>');
+        expect(
+            codec.encode(doc.toDelta()),
+            '<div class="checklist">'
+            '<div class="checklist-item"><input type="checkbox" checked disabled><label>&nbsp;Check - 1</label></div>'
+            '<div class="checklist-item"><input type="checkbox" disabled><label>&nbsp;Check - 2</label></div>'
+            '</div>'
+            '<p>A link to a <a href="https://example.com">site</a>.</p>');
       });
 
       test('Checklist followed by a paragraph', () {
@@ -486,8 +511,12 @@ void main() {
           {'insert': 'Paragraph\n'},
         ]);
 
-        expect(codec.encode(doc.toDelta()),
-            '<div class="checklist"><div class="checklist-item"><input type="checkbox" checked disabled><label>&nbsp;Check - 1</label></div><div class="checklist-item"><input type="checkbox" disabled><label>&nbsp;Check - 2</label></div></div><p>Paragraph</p>');
+        expect(
+            codec.encode(doc.toDelta()),
+            '<div class="checklist">'
+            '<div class="checklist-item"><input type="checkbox" checked disabled><label>&nbsp;Check - 1</label></div>'
+            '<div class="checklist-item"><input type="checkbox" disabled><label>&nbsp;Check - 2</label></div></div>'
+            '<p>Paragraph</p>');
       });
     });
 

--- a/packages/parchment/test/convert/html_test.dart
+++ b/packages/parchment/test/convert/html_test.dart
@@ -256,11 +256,11 @@ void main() {
 
         expect(
           codec.encode(doc.toDelta()),
-          '<pre><code>void main() {</code>\n'
-          '<code></code>\n'
-          '<code>  print("Hello World!");</code>\n'
-          '<code>}</code>\n'
-          '</pre>',
+          '<pre><code>void main() {\n'
+          '\n'
+          '  print("Hello World!");\n'
+          '}\n'
+          '</code></pre>',
         );
       });
 
@@ -275,8 +275,8 @@ void main() {
         ]);
         expect(
           codec.encode(doc.toDelta()),
-          '<pre><code>some code</code>\n'
-          '</pre><p>Hello world</p>',
+          '<pre><code>some code\n'
+          '</code></pre><p>Hello world</p>',
         );
       });
 
@@ -329,7 +329,7 @@ void main() {
           '<p>Hello world</p>'
           '<p>Hello world</p>'
           '<p>Hello world</p>'
-          '<pre><code>some code</code>\n</pre>'
+          '<pre><code>some code\n</code></pre>'
           '<p>Hello world</p>'
           '<blockquote style="margin: 0px 0px 0px 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;">some quote</blockquote>'
           '<p>Hello world</p>',
@@ -1459,11 +1459,10 @@ final htmlDoc = '<h1>Fleather</h1>'
     '</ul>'
     '<h2>Clean and modern look</h2>'
     '<p>Fleather’s rich text editor is built with <em>simplicity and flexibility</em> in mind. It provides clean interface for distraction-free editing. Think <code>Medium.com</code>-like experience.</p>'
-    '<pre>'
-    '<code>import ‘package:flutter/material.dart’;</code>\n'
-    '<code>import ‘package:parchment/parchment.dart’;</code>\n'
-    '<code></code>\n'
-    '<code>void main() {</code>\n'
-    '<code> print(“Hello world!”);</code>\n'
-    '<code>}</code>\n'
-    '</pre>';
+    '<pre><code>import ‘package:flutter/material.dart’;\n'
+    'import ‘package:parchment/parchment.dart’;\n'
+    '\n'
+    'void main() {\n'
+    ' print(“Hello world!”);\n'
+    '}\n'
+    '</code></pre>';

--- a/packages/parchment/test/convert/html_test.dart
+++ b/packages/parchment/test/convert/html_test.dart
@@ -256,11 +256,10 @@ void main() {
 
         expect(
           codec.encode(doc.toDelta()),
-          '<pre>'
-          'void main() {\n'
-          '\n'
-          '  print("Hello World!");\n'
-          '}\n'
+          '<pre><code>void main() {</code>\n'
+          '<code></code>\n'
+          '<code>  print("Hello World!");</code>\n'
+          '<code>}</code>\n'
           '</pre>',
         );
       });
@@ -276,8 +275,8 @@ void main() {
         ]);
         expect(
           codec.encode(doc.toDelta()),
-          '<pre>some code\n</pre>'
-          '<p>Hello world</p>',
+          '<pre><code>some code</code>\n'
+          '</pre><p>Hello world</p>',
         );
       });
 
@@ -330,7 +329,7 @@ void main() {
           '<p>Hello world</p>'
           '<p>Hello world</p>'
           '<p>Hello world</p>'
-          '<pre>some code\n</pre>'
+          '<pre><code>some code</code>\n</pre>'
           '<p>Hello world</p>'
           '<blockquote style="margin: 0px 0px 0px 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;">some quote</blockquote>'
           '<p>Hello world</p>',
@@ -1461,10 +1460,10 @@ final htmlDoc = '<h1>Fleather</h1>'
     '<h2>Clean and modern look</h2>'
     '<p>Fleather’s rich text editor is built with <em>simplicity and flexibility</em> in mind. It provides clean interface for distraction-free editing. Think <code>Medium.com</code>-like experience.</p>'
     '<pre>'
-    'import ‘package:flutter/material.dart’;\n'
-    'import ‘package:parchment/parchment.dart’;\n'
-    '\n'
-    'void main() {\n'
-    ' print(“Hello world!”);\n'
-    '}\n'
+    '<code>import ‘package:flutter/material.dart’;</code>\n'
+    '<code>import ‘package:parchment/parchment.dart’;</code>\n'
+    '<code></code>\n'
+    '<code>void main() {</code>\n'
+    '<code> print(“Hello world!”);</code>\n'
+    '<code>}</code>\n'
     '</pre>';

--- a/packages/parchment/test/convert/html_test.dart
+++ b/packages/parchment/test/convert/html_test.dart
@@ -446,6 +446,49 @@ void main() {
             '<div class="checklist-item"><input type="checkbox" disabled><label>&nbsp;item</label></div>'
             '</div>');
       });
+
+      test('Checklist followed by a link', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Check - 1'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'cl', 'checked': true}
+          },
+          {'insert': 'Check - 2'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'cl'}
+          },
+          {'insert': 'A link to a '},
+          {
+            'insert': 'site',
+            'attributes': {'a': 'https://example.com'}
+          },
+          {'insert': '.\n'}
+        ]);
+
+        expect(codec.encode(doc.toDelta()),
+            '<div class="checklist"><div class="checklist-item"><input type="checkbox" checked disabled><label>&nbsp;Check - 1</label></div><div class="checklist-item"><input type="checkbox" disabled><label>&nbsp;Check - 2</label></div></div><p>A link to a <a href="https://example.com">site</a>.</p>');
+      });
+
+      test('Checklist followed by a paragraph', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Check - 1'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'cl', 'checked': true}
+          },
+          {'insert': 'Check - 2'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'cl'}
+          },
+          {'insert': 'Paragraph\n'},
+        ]);
+
+        expect(codec.encode(doc.toDelta()),
+            '<div class="checklist"><div class="checklist-item"><input type="checkbox" checked disabled><label>&nbsp;Check - 1</label></div><div class="checklist-item"><input type="checkbox" disabled><label>&nbsp;Check - 2</label></div></div><p>Paragraph</p>');
+      });
     });
 
     group('Links', () {

--- a/packages/parchment/test/convert/html_test.dart
+++ b/packages/parchment/test/convert/html_test.dart
@@ -112,6 +112,39 @@ void main() {
         expect(codec.encode(doc.toDelta()),
             '<p>Line 1</p><p><br></p><p><br></p><p><br></p><p>Line 2</p><p>Line3</p><p>not blank1</p><p>not blank2</p><p>not blank3</p><p>Line 4</p><p><strong>Line 5</strong></p><p> <br></p><p><br></p><p><br></p><p><strong>Line 6</strong></p>');
       });
+
+      test('several styled lines in a row', () {
+        // Tests that we don't generate nested <p> tags.
+        final doc = ParchmentDocument.fromJson([
+          {
+            'insert': 'Bold',
+            'attributes': {'b': true}
+          },
+          {'insert': '\n'},
+          {
+            'insert': 'Italic',
+            'attributes': {'i': true}
+          },
+          {'insert': '\n'},
+          {
+            'insert': 'Bold',
+            'attributes': {'b': true}
+          },
+          {'insert': '\n'},
+          {
+            'insert': 'Italic',
+            'attributes': {'i': true}
+          },
+          {'insert': '\n'},
+          {
+            'insert': 'Bold',
+            'attributes': {'b': true}
+          },
+          {'insert': '\n'},
+        ]);
+        expect(codec.encode(doc.toDelta()),
+            '<p><strong>Bold</strong></p><p><em>Italic</em></p><p><strong>Bold</strong></p><p><em>Italic</em></p><p><strong>Bold</strong></p>');
+      });
     });
 
     group('Headings', () {
@@ -191,7 +224,7 @@ void main() {
           ]);
 
           expect(codec.encode(doc.toDelta()),
-              '<blockquote style="margin: 0px 0px 0px 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;">Hello World!</blockquote>');
+              '<blockquote style="margin: 0 0 0 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;">Hello World!</blockquote>');
         });
 
         test('Consecutive with same style', () {
@@ -210,8 +243,8 @@ void main() {
 
           expect(
               codec.encode(doc.toDelta()),
-              '<blockquote style="margin: 0px 0px 0px 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;">Hello World!</blockquote>'
-              '<blockquote style="margin: 0px 0px 0px 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;">Hello World!</blockquote>');
+              '<blockquote style="margin: 0 0 0 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;">Hello World!</blockquote>'
+              '<blockquote style="margin: 0 0 0 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;">Hello World!</blockquote>');
         });
 
         test('Consecutive with different styles', () {
@@ -230,8 +263,8 @@ void main() {
 
           expect(
               codec.encode(doc.toDelta()),
-              '<blockquote style="margin: 0px 0px 0px 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;">Hello World!</blockquote>'
-              '<blockquote style="text-align:center;margin: 0px 0px 0px 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;">Hello World!</blockquote>');
+              '<blockquote style="margin: 0 0 0 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;">Hello World!</blockquote>'
+              '<blockquote style="text-align:center;margin: 0 0 0 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;">Hello World!</blockquote>');
         });
       });
 
@@ -302,7 +335,7 @@ void main() {
           codec.encode(doc.toDelta()),
           '<p>Hello world</p>'
           '<p><strong>Another</strong> one</p>'
-          '<blockquote style="margin: 0px 0px 0px 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;">some <strong>quote</strong></blockquote>',
+          '<blockquote style="margin: 0 0 0 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;">some <strong>quote</strong></blockquote>',
         );
       });
 
@@ -331,7 +364,7 @@ void main() {
           '<p>Hello world</p>'
           '<pre><code>some code\n</code></pre>'
           '<p>Hello world</p>'
-          '<blockquote style="margin: 0px 0px 0px 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;">some quote</blockquote>'
+          '<blockquote style="margin: 0 0 0 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;">some quote</blockquote>'
           '<p>Hello world</p>',
         );
       });
@@ -721,25 +754,122 @@ void main() {
         );
       });
 
-      // TODO This test currently fails on an assertion: 'openBlockTags.length <= 1'
       test('Multi-level lists with trailing paragraph', () {
         final doc = ParchmentDocument.fromJson([
           {'insert': 'Test\n'},
-          {'insert': 'Multi-level lists'},
+          {'insert': 'Level 1 - 1'},
           {
             'insert': '\n',
             'attributes': {'block': 'ol'}
           },
-          {'insert': 'with trailing paragraph'},
+          {'insert': 'Level 1 - 2'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          },
+          {'insert': 'Level 2 - 1'},
           {
             'insert': '\n',
             'attributes': {'block': 'ol', 'indent': 1}
           },
-          {'insert': 'End\n'}
+          {'insert': 'Level 2 - 2'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'indent': 1}
+          },
+          {'insert': 'No longer in list\n'}
         ]);
         expect(codec.encode(doc.toDelta()),
-            '<p>Test</p><ol><li>Multi-level lists</li><ol><li>with trailing paragraph</li></ol></ol><p>End</p>');
-      }, skip: true);
+            '<p>Test</p><ol><li>Level 1 - 1</li><li>Level 1 - 2</li><ol><li>Level 2 - 1</li><li>Level 2 - 2</li></ol></ol><p>No longer in list</p>');
+      });
+
+      test('Extreme multi-level lists with trailing paragraph', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Test\n'},
+          {'insert': 'Level 1 - 1'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          },
+          {'insert': 'Level 1 - 2'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          },
+          {'insert': 'Level 2 - 1'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'indent': 1}
+          },
+          {'insert': 'Level 2 - 2'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'indent': 1}
+          },
+          {'insert': 'Level 3 - 1'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'indent': 2}
+          },
+          {'insert': 'Level 3 - 2'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'indent': 2}
+          },
+          {'insert': 'Level 4 - 1'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'indent': 3}
+          },
+          {'insert': 'Level 4 - 2'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'indent': 3}
+          },
+          {'insert': 'No longer in list\n'}
+        ]);
+        expect(codec.encode(doc.toDelta()),
+            '<p>Test</p><ol><li>Level 1 - 1</li><li>Level 1 - 2</li><ol><li>Level 2 - 1</li><li>Level 2 - 2</li><ol><li>Level 3 - 1</li><li>Level 3 - 2</li><ol><li>Level 4 - 1</li><li>Level 4 - 2</li></ol></ol></ol></ol><p>No longer in list</p>');
+      });
+
+      test('Multiple Multi-level lists', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Test\n'},
+          {'insert': 'Level 1 - 1'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          },
+          {'insert': 'Level 1 - 2'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          },
+          {'insert': 'Level 2 - 1'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'indent': 1}
+          },
+          {'insert': 'Level 2 - 2'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol', 'indent': 1}
+          },
+          {'insert': 'No longer in list\n'},
+          {'insert': 'In a new list - 1'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          },
+          {'insert': 'In a new list - 2'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'ol'}
+          },
+        ]);
+        expect(codec.encode(doc.toDelta()),
+            '<p>Test</p><ol><li>Level 1 - 1</li><li>Level 1 - 2</li><ol><li>Level 2 - 1</li><li>Level 2 - 2</li></ol></ol><p>No longer in list</p><ol><li>In a new list - 1</li><li>In a new list - 2</li></ol>');
+      });
 
       test('Paragraph with margin', () {
         final doc = ParchmentDocument.fromJson([
@@ -755,7 +885,7 @@ void main() {
             '<p style="padding-left:32px;">Something in the way...</p>');
       });
 
-      test('Quotes with margin', () {
+      test('Quotes with indent', () {
         final doc = ParchmentDocument.fromJson([
           {'insert': 'Something in the way...\nSomething in the way...'},
           {
@@ -766,7 +896,25 @@ void main() {
         expect(
             codec.encode(doc.toDelta()),
             '<p>Something in the way...</p>'
-            '<blockquote style="padding-left:32px;margin: 0px 0px 0px 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;">Something in the way...</blockquote>');
+            '<blockquote style="margin: 0 0 0 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;padding-left:32px;">Something in the way...</blockquote>');
+      });
+
+      test('Quote with embedded heading', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'Quote'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'quote'}
+          },
+          {'insert': 'header'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'quote', 'heading': 1}
+          },
+          {'insert': 'Not in quote\n'},
+        ]);
+        expect(codec.encode(doc.toDelta()),
+            '<blockquote style="margin: 0 0 0 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;">Quote</blockquote><blockquote style="margin: 0 0 0 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;"><h1 style="margin: 0 0 0 0.8ex; border-left: 1px solid rgb(204, 204, 204); padding-left: 1ex;">header</blockquote></h1><p>Not in quote</p>');
       });
     });
 

--- a/packages/parchment/test/convert/html_test.dart
+++ b/packages/parchment/test/convert/html_test.dart
@@ -333,6 +333,26 @@ void main() {
         );
       });
 
+      test('Code then bold paragraph', () {
+        final doc = ParchmentDocument.fromJson([
+          {'insert': 'some code'},
+          {
+            'insert': '\n',
+            'attributes': {'block': 'code'}
+          },
+          {
+            'insert': 'Hello world',
+            'attributes': {'b': true}
+          },
+          {'insert': '\n'}
+        ]);
+        expect(
+          codec.encode(doc.toDelta()),
+          '<pre><code>some code\n'
+          '</code></pre><p><strong>Hello world</strong></p>',
+        );
+      });
+
       test('Paragraphs then quote', () {
         final doc = ParchmentDocument.fromJson([
           {'insert': 'Hello world\n'},


### PR DESCRIPTION
Fixes to _ParchmentHtmlEncoder:
1. `ParchmentHtmlCodec` wasn't exported from the package. :smiley: 
1. Text with empty line breaks did not render as blank lines.
2. Text with HTML characters such as < > and & were not escaped.
3. Code blocks (&lt;pre>) were not rendering with line breaks.
4. Block quotes (&lt;blockquote>) were not rendering in the fashion that you see in Fleather, or that you'd typically see in HTML email. 
5. Checklist changes - Added some space between the checkbox and the label, they rendered kind of jammed together. Also, render the checkbox as disabled so the user cannot check/uncheck it.
6. There was an issue with multi-level lists with a plain paragraph following them - the paragraph would get rendering in the list. 
7. Render images so that they will fit within the parent's width, if any. If the parent doesn't have any width, this does nothing. This is useful when generation email HTML, for example, so that the image doesn't bleed out of view.
8. Fix checklist followed by a paragraph.

cc: @amantoux 