### PR TITLE
more graceful error handling

### DIFF
--- a/packages/fleather/lib/src/widgets/text_line.dart
+++ b/packages/fleather/lib/src/widgets/text_line.dart
@@ -165,19 +165,25 @@ class _TextLineState extends State<TextLine> {
   }
 
   InlineSpan _segmentToTextSpan(Node segment, FleatherThemeData theme) {
-    if (segment is EmbedNode) {
-      return WidgetSpan(
-          child: EmbedProxy(child: widget.embedBuilder(context, segment)));
+    try {
+      if (segment is EmbedNode) {
+        return WidgetSpan(
+            child: EmbedProxy(child: widget.embedBuilder(context, segment)));
+      }
+      final text = segment as TextNode;
+      final attrs = text.style;
+      final isLink = attrs.contains(ParchmentAttribute.link);
+      return TextSpan(
+        text: text.value,
+        style: _getInlineTextStyle(attrs, widget.node.style, theme),
+        recognizer: isLink && canLaunchLinks ? _getRecognizer(segment) : null,
+        mouseCursor: isLink && canLaunchLinks ? SystemMouseCursors.click : null,
+      );
+    } catch (err) {
+      return TextSpan(
+          text: 'error: $err',
+          style: const TextStyle(backgroundColor: Colors.red));
     }
-    final text = segment as TextNode;
-    final attrs = text.style;
-    final isLink = attrs.contains(ParchmentAttribute.link);
-    return TextSpan(
-      text: text.value,
-      style: _getInlineTextStyle(attrs, widget.node.style, theme),
-      recognizer: isLink && canLaunchLinks ? _getRecognizer(segment) : null,
-      mouseCursor: isLink && canLaunchLinks ? SystemMouseCursors.click : null,
-    );
   }
 
   GestureRecognizer _getRecognizer(Node segment) {

--- a/packages/parchment/lib/src/document.dart
+++ b/packages/parchment/lib/src/document.dart
@@ -305,8 +305,10 @@ class ParchmentDocument {
 
   /// Loads [document] delta into this document.
   void _loadDocument(Delta doc) {
-    assert((doc.last.data as String).endsWith('\n'),
-        'Invalid document delta. Document delta must always end with a line-break.');
+    if (!(doc.last.data as String).endsWith('\n')) {
+      throw ArgumentError.value(doc,
+          'Invalid document delta. Document delta must always end with a line-break.');
+    }
     var offset = 0;
     for (final op in doc.toList()) {
       final style =


### PR DESCRIPTION
- document: throw instead of assert when document is invalid, invalid document is just a valid error, leave a chance to the user of the API to fix it.
- display an error instead of throwing on invalid textspan / embed.
Another fix may be avoid throwing on in the default embed builder.

what do you think?