### PR TITLE
WIP: Anchors & customTextSpan

### DIFF
--- a/packages/fleather/lib/src/rendering/cursor_painter.dart
+++ b/packages/fleather/lib/src/rendering/cursor_painter.dart
@@ -14,20 +14,19 @@ class CursorPainter {
   final RenderContentProxyBox editable;
   final CursorStyle style;
   final Rect cursorPrototype;
-  final Color effectiveColor;
   final double devicePixelRatio;
 
   CursorPainter({
     required this.editable,
     required this.style,
     required this.cursorPrototype,
-    required this.effectiveColor,
     required this.devicePixelRatio,
   });
 
   /// Paints cursor on [canvas] at specified [textPosition].
-  void paint(Canvas canvas, Offset effectiveOffset, TextPosition textPosition) {
-    final paint = Paint()..color = effectiveColor;
+  void paint(Canvas canvas, Offset effectiveOffset, TextPosition textPosition,
+      Color color) {
+    final paint = Paint()..color = color;
     final Offset caretOffset =
         editable.getOffsetForCaret(textPosition, cursorPrototype) +
             effectiveOffset;

--- a/packages/fleather/lib/src/rendering/editable_text_line.dart
+++ b/packages/fleather/lib/src/rendering/editable_text_line.dart
@@ -722,7 +722,9 @@ class RenderEditableTextLine extends RenderEditableBox {
         _selectionRects ??= body!.getBoxesForSelection(
           local, /*, boxHeightStyle: _selectionHeightStyle, boxWidthStyle: _selectionWidthStyle*/
         );
-        _paintSelection(context, effectiveOffset);
+        assert(_selectionRects != null);
+        _paintSelection(
+            context, effectiveOffset, _selectionRects!, _selectionColor);
       }
 
       if (hasFocus &&
@@ -743,13 +745,13 @@ class RenderEditableTextLine extends RenderEditableBox {
     }
   }
 
-  void _paintSelection(PaintingContext context, Offset effectiveOffset) {
+  void _paintSelection(PaintingContext context, Offset effectiveOffset,
+      List<TextBox> rects, Color color) {
     // assert(_textLayoutLastMaxWidth == constraints.maxWidth &&
     //     _textLayoutLastMinWidth == constraints.minWidth,
     // 'Last width ($_textLayoutLastMinWidth, $_textLayoutLastMaxWidth) not the same as max width constraint (${constraints.minWidth}, ${constraints.maxWidth}).');
-    assert(_selectionRects != null);
-    final paint = Paint()..color = _selectionColor;
-    for (final box in _selectionRects!) {
+    final paint = Paint()..color = color;
+    for (final box in rects) {
       context.canvas.drawRect(box.toRect().shift(effectiveOffset), paint);
     }
   }

--- a/packages/fleather/lib/src/rendering/editable_text_line.dart
+++ b/packages/fleather/lib/src/rendering/editable_text_line.dart
@@ -680,9 +680,6 @@ class RenderEditableTextLine extends RenderEditableBox {
       editable: body!,
       style: _cursorController.style,
       cursorPrototype: _caretPrototype,
-      effectiveColor: _cursorController.isFloatingCursorActive
-          ? _cursorController.style.backgroundColor
-          : _cursorController.cursorColor.value,
       devicePixelRatio: devicePixelRatio);
 
   @override
@@ -772,7 +769,10 @@ class RenderEditableTextLine extends RenderEditableBox {
         : TextPosition(
             offset: selection.extentOffset - node.documentOffset,
             affinity: selection.base.affinity);
-    _cursorPainter.paint(context.canvas, effectiveOffset, textPosition);
+    final color = _cursorController.isFloatingCursorActive
+        ? _cursorController.style.backgroundColor
+        : _cursorController.cursorColor.value;
+    _cursorPainter.paint(context.canvas, effectiveOffset, textPosition, color);
   }
 
   @override

--- a/packages/fleather/lib/src/rendering/editor.dart
+++ b/packages/fleather/lib/src/rendering/editor.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_portal/enhanced_composited_transform.dart';
 
 import '../../fleather.dart';
 import '../widgets/selection_utils.dart';
@@ -133,6 +134,8 @@ class RenderEditor extends RenderEditableContainerBox
     required LayerLink endHandleLayerLink,
     required EdgeInsetsGeometry padding,
     required CursorController cursorController,
+    required List<TextAnchor> textAnchors,
+    required RenderBox Function()? portalTheater,
     this.onSelectionChanged,
     EdgeInsets floatingCursorAddedMargin =
         const EdgeInsets.fromLTRB(4, 4, 4, 5),
@@ -145,6 +148,8 @@ class RenderEditor extends RenderEditableContainerBox
         _endHandleLayerLink = endHandleLayerLink,
         _cursorController = cursorController,
         _maxContentWidth = maxContentWidth,
+        _textAnchors = textAnchors,
+        _portalTheater = portalTheater,
         super(
           children: children,
           node: document.root,
@@ -153,6 +158,9 @@ class RenderEditor extends RenderEditableContainerBox
         );
 
   ParchmentDocument _document;
+  EnhancedLayerLink docLayerLink = EnhancedLayerLink();
+  List<TextAnchor> _textAnchors;
+  RenderBox Function()? _portalTheater;
 
   set document(ParchmentDocument value) {
     if (_document == value) {
@@ -160,6 +168,18 @@ class RenderEditor extends RenderEditableContainerBox
     }
     _document = value;
     markNeedsLayout();
+  }
+
+  set textAnchors(List<TextAnchor> textAnchors) {
+    if (textAnchors == _textAnchors) return;
+    _textAnchors = textAnchors;
+    markNeedsPaint();
+  }
+
+  set portalTheater(RenderBox Function()? portalTheater) {
+    if (_portalTheater == portalTheater) return;
+    _portalTheater = portalTheater;
+    markNeedsPaint();
   }
 
   /// Whether the editor is currently focused.
@@ -678,6 +698,7 @@ class RenderEditor extends RenderEditableContainerBox
     defaultPaint(context, offset);
     _updateSelectionExtentsVisibility(offset + _paintOffset);
     _paintHandleLayers(context, getEndpointsForSelection(selection));
+    // _paintTextAnchors(context, offset);
 
     if (hasFocus &&
         _cursorController.showCursor.value &&
@@ -716,6 +737,30 @@ class RenderEditor extends RenderEditableContainerBox
       );
     }
   }
+
+  // void _paintTextAnchors(PaintingContext context, Offset offset2) {
+  //   for (var anchor in _textAnchors) {
+  //     final p = anchor.pos;
+  //     final offset = _getOffsetForCaret(p);
+
+  //     Rect getTheatherRect() {
+  //       assert(_portalTheater != null);
+  //       final theater = _portalTheater!();
+  //       final shift = globalToLocal(Offset.zero, ancestor: theater) - offset;
+  //       final r = shift & theater.size;
+  //       return r;
+  //     }
+
+  //     context.pushLayer(
+  //         EnhancedLeaderLayer(
+  //             debugName: 'anchor',
+  //             offset: offset,
+  //             link: anchor.layerLink,
+  //             theaterRectRelativeToLeader: getTheatherRect),
+  //         super.paint,
+  //         Offset.zero);
+  //   }
+  // }
 
   @override
   double preferredLineHeight(TextPosition position) {

--- a/packages/fleather/lib/src/rendering/paragraph_proxy.dart
+++ b/packages/fleather/lib/src/rendering/paragraph_proxy.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/rendering.dart';
+import 'package:flutter_portal/enhanced_composited_transform.dart';
 
 import 'editable_box.dart';
 
@@ -12,6 +13,8 @@ class RenderParagraphProxy extends RenderProxyBox
     required TextStyle textStyle,
     required double textScaleFactor,
     required TextWidthBasis textWidthBasis,
+    required this.layerLink,
+    RenderBox Function()? portalTheater,
     RenderParagraph? child,
     TextDirection? textDirection,
     StrutStyle? strutStyle,
@@ -26,9 +29,12 @@ class RenderParagraphProxy extends RenderProxyBox
             locale: locale,
             textWidthBasis: textWidthBasis,
             textHeightBehavior: textHeightBehavior),
+        _portalTheater = portalTheater,
         super(child);
 
   final TextPainter _prototypePainter;
+  final EnhancedLayerLink layerLink;
+  RenderBox Function()? _portalTheater;
 
   set textStyle(TextStyle value) {
     if (_prototypePainter.text!.style == value) return;
@@ -78,6 +84,12 @@ class RenderParagraphProxy extends RenderProxyBox
     markNeedsLayout();
   }
 
+  set portalTheater(RenderBox Function()? value) {
+    if (_portalTheater == value) return;
+    _portalTheater = value;
+    markNeedsPaint();
+  }
+
   @override
   RenderParagraph? get child => super.child as RenderParagraph?;
 
@@ -115,5 +127,26 @@ class RenderParagraphProxy extends RenderProxyBox
     super.performLayout();
     _prototypePainter.layout(
         minWidth: constraints.minWidth, maxWidth: constraints.maxWidth);
+  }
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    Rect getTheatherRect() {
+      assert(_portalTheater != null);
+      final theater = _portalTheater!();
+      final shift = globalToLocal(Offset.zero, ancestor: theater) /*- offset*/;
+      final r = shift & theater.size;
+      return r;
+    }
+
+    context.pushLayer(
+        EnhancedLeaderLayer(
+          debugName: '42',
+          link: layerLink,
+          offset: offset,
+          theaterRectRelativeToLeader: getTheatherRect,
+        ),
+        super.paint,
+        Offset.zero);
   }
 }

--- a/packages/fleather/lib/src/widgets/editable_text_block.dart
+++ b/packages/fleather/lib/src/widgets/editable_text_block.dart
@@ -2,7 +2,6 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:parchment/parchment.dart';
 import 'package:fleather/util.dart';
-
 import '../rendering/editable_text_block.dart';
 import 'controller.dart';
 import 'cursor.dart';
@@ -26,6 +25,9 @@ class EditableTextBlock extends StatelessWidget {
   final LinkActionPicker linkActionPicker;
   final ValueChanged<String?>? onLaunchUrl;
   final EdgeInsets? contentPadding;
+  final List<TextAnchor> textAnchors;
+  final CustomTextSpan? customTextSpan;
+  final RenderBox Function() portalTheater;
 
   const EditableTextBlock({
     Key? key,
@@ -40,6 +42,9 @@ class EditableTextBlock extends StatelessWidget {
     required this.hasFocus,
     required this.embedBuilder,
     required this.linkActionPicker,
+    required this.textAnchors,
+    this.customTextSpan,
+    required this.portalTheater,
     this.onLaunchUrl,
     this.contentPadding,
   }) : super(key: key);
@@ -82,12 +87,16 @@ class EditableTextBlock extends StatelessWidget {
             embedBuilder: embedBuilder,
             linkActionPicker: linkActionPicker,
             onLaunchUrl: onLaunchUrl,
+            customTextSpan: customTextSpan,
+            portalTheater: portalTheater,
           ),
           cursorController: cursorController,
           selection: selection,
           selectionColor: selectionColor,
+          textAnchors: textAnchors,
           enableInteractiveSelection: enableInteractiveSelection,
           hasFocus: hasFocus,
+          portalTheater: portalTheater,
         ),
       ));
       index++;

--- a/packages/fleather/lib/src/widgets/editable_text_line.dart
+++ b/packages/fleather/lib/src/widgets/editable_text_line.dart
@@ -3,6 +3,7 @@ import 'package:parchment/parchment.dart';
 
 import '../rendering/editable_box.dart';
 import '../rendering/editable_text_line.dart';
+import 'controller.dart';
 import 'cursor.dart';
 import 'text_line.dart';
 import 'theme.dart';
@@ -32,6 +33,8 @@ class EditableTextLine extends RenderObjectWidget {
   final bool enableInteractiveSelection;
   final bool hasFocus;
   final double devicePixelRatio;
+  final List<TextAnchor> textAnchors;
+  final RenderBox Function() portalTheater;
 
   /// Creates an editable line of text.
   const EditableTextLine({
@@ -44,6 +47,8 @@ class EditableTextLine extends RenderObjectWidget {
     required this.enableInteractiveSelection,
     required this.hasFocus,
     required this.devicePixelRatio,
+    required this.textAnchors,
+    required this.portalTheater,
     this.leading,
     this.indentWidth = 0.0,
     this.spacing = const VerticalSpacing(),
@@ -72,6 +77,8 @@ class EditableTextLine extends RenderObjectWidget {
       hasFocus: hasFocus,
       devicePixelRatio: devicePixelRatio,
       inlineCodeTheme: theme.inlineCode,
+      textAnchors: textAnchors,
+      portalTheater: portalTheater,
     );
   }
 
@@ -85,10 +92,12 @@ class EditableTextLine extends RenderObjectWidget {
     renderObject.cursorController = cursorController;
     renderObject.selection = selection;
     renderObject.selectionColor = selectionColor;
+    renderObject.textAnchors = textAnchors;
     renderObject.enableInteractiveSelection = enableInteractiveSelection;
     renderObject.hasFocus = hasFocus;
     renderObject.devicePixelRatio = devicePixelRatio;
     renderObject.inlineCodeTheme = theme.inlineCode;
+    renderObject.portalTheater = portalTheater;
   }
 }
 

--- a/packages/fleather/lib/src/widgets/field.dart
+++ b/packages/fleather/lib/src/widgets/field.dart
@@ -1,3 +1,4 @@
+import 'package:fleather/fleather.dart';
 import 'package:flutter/material.dart';
 import 'package:parchment/parchment.dart';
 
@@ -140,6 +141,17 @@ class FleatherField extends StatefulWidget {
 
   final GlobalKey<EditorState>? editorKey;
 
+  /// Support overriding the default textSpan construction function
+  /// useful to subscribe to mouseEnter / mouseExit
+  /// it is also possible to get the layerlink of a paragraph that way.
+  /// (useful for mentions)
+  final CustomTextSpan? customTextSpan;
+
+  /// When using layerLink (either in customTextSpan or in Anchors) the reference
+  /// overlay from which the overlays wont "escape"
+  /// defaults to the root overlay
+  final RenderBox Function()? portalTheater;
+
   const FleatherField({
     Key? key,
     required this.controller,
@@ -162,6 +174,8 @@ class FleatherField extends StatefulWidget {
     this.decoration,
     this.toolbar,
     this.embedBuilder = defaultFleatherEmbedBuilder,
+    this.customTextSpan,
+    this.portalTheater,
   }) : super(key: key);
 
   @override
@@ -227,6 +241,8 @@ class _FleatherFieldState extends State<FleatherField> {
       scrollPhysics: widget.scrollPhysics,
       onLaunchUrl: widget.onLaunchUrl,
       embedBuilder: widget.embedBuilder,
+      customTextSpan: widget.customTextSpan,
+      portalTheater: widget.portalTheater,
     );
 
     if (widget.toolbar != null) {

--- a/packages/fleather/lib/src/widgets/rich_text_proxy.dart
+++ b/packages/fleather/lib/src/widgets/rich_text_proxy.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:flutter_portal/enhanced_composited_transform.dart';
 
 import '../rendering/paragraph_proxy.dart';
 
@@ -7,15 +8,18 @@ class RichTextProxy extends SingleChildRenderObjectWidget {
   const RichTextProxy({
     Key? key,
     required RichText child,
+    required this.layerLink,
     required this.textStyle,
     required this.locale,
     required this.strutStyle,
     required this.textAlign,
+    required this.portalTheater,
     this.textScaleFactor = 1.0,
     this.textWidthBasis = TextWidthBasis.parent,
     this.textHeightBehavior,
   }) : super(key: key, child: child);
 
+  final EnhancedLayerLink layerLink;
   final TextStyle textStyle;
   final TextAlign textAlign;
   final double textScaleFactor;
@@ -24,9 +28,13 @@ class RichTextProxy extends SingleChildRenderObjectWidget {
   final TextWidthBasis textWidthBasis;
   final TextHeightBehavior? textHeightBehavior;
 
+  final RenderBox Function()? portalTheater;
+
   @override
   RenderParagraphProxy createRenderObject(BuildContext context) {
     return RenderParagraphProxy(
+      layerLink: layerLink,
+      portalTheater: portalTheater,
       textStyle: textStyle,
       textDirection: Directionality.of(context),
       textScaleFactor: textScaleFactor,
@@ -48,5 +56,6 @@ class RichTextProxy extends SingleChildRenderObjectWidget {
     renderObject.strutStyle = strutStyle;
     renderObject.textWidthBasis = textWidthBasis;
     renderObject.textHeightBehavior = textHeightBehavior;
+    renderObject.portalTheater = portalTheater;
   }
 }

--- a/packages/fleather/lib/src/widgets/text_line.dart
+++ b/packages/fleather/lib/src/widgets/text_line.dart
@@ -165,19 +165,25 @@ class _TextLineState extends State<TextLine> {
   }
 
   InlineSpan _segmentToTextSpan(Node segment, FleatherThemeData theme) {
-    if (segment is EmbedNode) {
-      return WidgetSpan(
-          child: EmbedProxy(child: widget.embedBuilder(context, segment)));
+    try {
+      if (segment is EmbedNode) {
+        return WidgetSpan(
+            child: EmbedProxy(child: widget.embedBuilder(context, segment)));
+      }
+      final text = segment as TextNode;
+      final attrs = text.style;
+      final isLink = attrs.contains(ParchmentAttribute.link);
+      return TextSpan(
+        text: text.value,
+        style: _getInlineTextStyle(attrs, widget.node.style, theme),
+        recognizer: isLink && canLaunchLinks ? _getRecognizer(segment) : null,
+        mouseCursor: isLink && canLaunchLinks ? SystemMouseCursors.click : null,
+      );
+    } catch (err) {
+      return TextSpan(
+          text: 'error: $err',
+          style: const TextStyle(backgroundColor: Colors.red));
     }
-    final text = segment as TextNode;
-    final attrs = text.style;
-    final isLink = attrs.contains(ParchmentAttribute.link);
-    return TextSpan(
-      text: text.value,
-      style: _getInlineTextStyle(attrs, widget.node.style, theme),
-      recognizer: isLink && canLaunchLinks ? _getRecognizer(segment) : null,
-      mouseCursor: isLink && canLaunchLinks ? SystemMouseCursors.click : null,
-    );
   }
 
   GestureRecognizer _getRecognizer(Node segment) {

--- a/packages/fleather/pubspec.yaml
+++ b/packages/fleather/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
   parchment:
     path: ../parchment
   characters: ^1.2.0
+  flutter_portal: ^1.1.3
+
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This is a WIP mostly because I believe the API is quite brittle. It is working nicely for me. 
I wonder what is the best way to integrate all that. Do you have ideas for the API? Should we provide the whole overlay system.

It currently uses the internals of flutter_portal so that everything can align nicely and stay within the overlay window if requested. (this is what portalTheater is useful for)

Mention are based on a branch of fleather_mention by @Amir-P, see here: https://github.com/jotshq/fleather_mention
PS: the mention branch has not been cleaned yet.

They enable the following workflows:
<table>
  <tr>
    <td>/ triggers a mention autocomplete</td>
     <td>overlay on hover</td>
     <td>floating toolbar</td>
  </tr>
  <tr>
<td><img width="267" alt="Screenshot 2022-12-16 at 21 21 28" src="https://user-images.githubusercontent.com/49141/208055398-3ad7240d-0d2d-4ac8-98a8-79bad5d3ab50.png">
</td><td>

<img width="315" alt="Screenshot 2022-12-16 at 21 23 11" src="https://user-images.githubusercontent.com/49141/208055412-d6cdc899-258a-4656-bf64-c9dd855df533.png"> 
</td><td>
<img width="241" alt="Screenshot 2022-12-16 at 21 22 18" src="https://user-images.githubusercontent.com/49141/208055408-62ad3656-29ff-4aa8-ad61-ed13f5368fac.png">
</td>
  </tr>
 </table>

== Anchors ==

Anchors have two modes:
- withLayerLink: allows having a layerLink associated to a TextPosition
- Selection: to draw a selection or cursor

The first mode is useful for properly positioning mentions or a floating toolbar.
The second mode is useful for remote selections.

I plan to rebase the TextSelection like we do with the main selection on changes. (yet to implement)

== customTextSpan ==

customTextSpan allows overriding the construction of our textSpans. It is useful to get access to mouseEnter/mouseExit and also provide a layerLink associated with the current rendered line.
It can be used for displaying overlays when hovering a mention or a link.


