### PR TITLE
Ensure that text boxes are only the required size

### DIFF
--- a/packages/fleather/lib/src/rendering/editable_box.dart
+++ b/packages/fleather/lib/src/rendering/editable_box.dart
@@ -311,9 +311,8 @@ class RenderEditableContainerBox extends RenderBox
 
     var mainAxisExtent = _resolvedPadding!.top;
     var child = firstChild;
-    final innerConstraints =
-        BoxConstraints.tightFor(width: constraints.maxWidth)
-            .deflate(_resolvedPadding!);
+    final innerConstraints = BoxConstraints(maxWidth: constraints.maxWidth)
+        .deflate(_resolvedPadding!);
     while (child != null) {
       child.layout(innerConstraints, parentUsesSize: true);
       final childParentData = child.parentData as EditableContainerParentData;


### PR DESCRIPTION
Otherwise hitTest are wrong and onEnter/onExit/recognizer/mouseCursor of TextSpans recognise the trailing empty space as a hit while it actually is not.

## Before:
https://user-images.githubusercontent.com/49141/208324135-26cd552d-403f-41e3-a554-469c7b183e6a.mov

![image](https://user-images.githubusercontent.com/49141/208324368-ffe30cd5-7a91-4a09-83a5-28bd1fe81b8f.png)

## After:
https://user-images.githubusercontent.com/49141/208324132-a03ce4f7-f1d0-4af4-92d7-be37f2bca324.mov

![image](https://user-images.githubusercontent.com/49141/208324399-912df5a6-baf5-4e73-950b-981a7dcc75a0.png)


