### PR TITLE
Format link after hitting newline

### DIFF
--- a/packages/parchment/lib/src/heuristics/insert_rules.dart
+++ b/packages/parchment/lib/src/heuristics/insert_rules.dart
@@ -139,15 +139,13 @@ class ResetLineFormatOnNewLineRule extends InsertRule {
     if (targetText.startsWith('\n')) {
       if (target.attributes != null &&
           target.attributes!.containsKey(ParchmentAttribute.heading.key)) {
+        // Reset heading style
         final resetStyle = ParchmentAttribute.heading.unset.toJson();
         return Delta()
           ..retain(index)
           ..insert('\n', target.attributes)
           ..retain(1, resetStyle)
           ..trim();
-      } else {
-        // Nothing needs to be reset
-        return null;
       }
     }
     return null;

--- a/packages/parchment/test/heuristics/insert_rules_test.dart
+++ b/packages/parchment/test/heuristics/insert_rules_test.dart
@@ -75,14 +75,10 @@ void main() {
       expect(actual, expected);
     });
 
-    test('applies without style reset if not needed', () {
+    test("doesn't apply without style reset if not needed", () {
       final doc = Delta()..insert('Hello world\n');
       final actual = rule.apply(doc, 11, '\n');
-      expect(actual, isNotNull);
-      final expected = Delta()
-        ..retain(11)
-        ..insert('\n');
-      expect(actual, expected);
+      expect(actual, isNull);
     });
 
     test('applies at the beginning of a document', () {
@@ -217,6 +213,16 @@ void main() {
       expect(expected, actual);
     });
 
+    test('apply simple newline', () {
+      final doc = Delta()..insert('Doc with link https://example.com');
+      final actual = rule.apply(doc, 33, '\n');
+      final expected = Delta()
+        ..retain(14)
+        ..retain(19, link)
+        ..insert('\n');
+      expect(expected, actual);
+    });
+
     test('applies only to insert of single space', () {
       final doc = Delta()..insert('Doc with link https://example.com');
       final actual = rule.apply(doc, 33, '/');
@@ -257,6 +263,18 @@ void main() {
         ..insert('also ')
         ..insert('\n', ul);
       expect(actual, isNotNull);
+      expect(actual, expected);
+    });
+
+    test('formats a link in a block', () {
+      final link = ParchmentAttribute.link.fromString('http://a.com').toJson();
+      final doc = Delta()
+        ..insert('http://a.com')
+        ..insert('\n', ul);
+      final actual = rule.apply(doc, 12, '\n');
+      final expected = Delta()
+        ..retain(12, link)
+        ..insert('\n', ul);
       expect(actual, expected);
     });
 


### PR DESCRIPTION
Works in the block and outside the block.

[Screencast from 2023-01-06 21-10-53.webm](https://user-images.githubusercontent.com/627197/211082729-4ee70c20-d2c7-46ab-a2ae-20babe966cfe.webm)
