### PR TITLE
Upgrade intl to 0.18 to ensure compatibility with `flutter_localizations`

### DIFF
--- a/packages/parchment/pubspec.yaml
+++ b/packages/parchment/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   collection: ^1.16.0
   quill_delta: ^3.0.0-nullsafety.2
   quiver: ^3.1.0
-  intl: ^0.17.0
+  intl: ^0.18.0
   html: ^0.15.1
 
 dev_dependencies:


### PR DESCRIPTION
Following https://github.com/fleather-editor/fleather/pull/117, with Flutter 3.10, `flutter_localizations` requires `intl: 0.18.0`
