### PR TITLE
Upload to codecov lies in its own job

### DIFF
--- a/.github/workflows/fleather.yml
+++ b/.github/workflows/fleather.yml
@@ -58,6 +58,28 @@ jobs:
         working-directory: ./packages/fleather
         run: flutter test --coverage
 
+      - name: Cache - Save coverage
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            ./packages/parchment/coverage/lcov.info
+            ./packages/fleather/coverage/lcov.info
+          key: cov-files
+
+  upload-codecov:
+    runs-on: ubuntu-latest
+
+    needs: build
+
+    steps:
+      - name: Cache - Restore coverage
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            ./packages/parchment/coverage/lcov.info
+            ./packages/fleather/coverage/lcov.info
+          key: cov-files
+
       - name: Codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
Codecov upload fails for randomly from time to time
To avoid re-running all tests we split the build job in 2 job (build & upload-codecov)
If upload to codecov fails, then we only need to re-run the latter instead of the entire build