### PR TITLE
Fix Kotlin version preventing build of example on Android

### DIFF
--- a/packages/fleather/example/android/build.gradle
+++ b/packages/fleather/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.9.21'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
```
─ Flutter Fix ────────────────────────────
[!] Your project requires a newer version of the Kotlin Gradle plugin.
Find the latest version on https://kotlinlang.org/docs/releases.html#release-details, then update 
/Users/.../fleather/packages/fleather/example/android/build.gradle:
ext.kotlin_version = '<latest-version>'
```