### PR TITLE
Fix text direction auto format detection and undo

### DIFF
--- a/packages/fleather/lib/src/widgets/autoformats.dart
+++ b/packages/fleather/lib/src/widgets/autoformats.dart
@@ -47,9 +47,12 @@ class AutoFormats {
   /// The position at which the active suggestion can be deactivated
   int get undoPosition => _activeSuggestion!.undoPositionCandidate;
 
-  /// `true` if there is an active suggestion and undo delta is not empty;
+  /// `true` if there is an active suggestion; `false` otherwise
+  bool get hasActiveSuggestion => _activeSuggestion != null;
+
+  /// `true` if hasActiveSuggestion and undo delta is not empty;
   /// `false` otherwise
-  bool get canUndo => _activeSuggestion?.undo.isNotEmpty == true;
+  bool get canUndo => hasActiveSuggestion && _activeSuggestion!.undo.isNotEmpty;
 
   /// Perform detection of auto formats and apply changes to [document].
   ///

--- a/packages/fleather/lib/src/widgets/autoformats.dart
+++ b/packages/fleather/lib/src/widgets/autoformats.dart
@@ -47,8 +47,9 @@ class AutoFormats {
   /// The position at which the active suggestion can be deactivated
   int get undoPosition => _activeSuggestion!.undoPositionCandidate;
 
-  /// `true` if there is an active suggestion; `false` otherwise
-  bool get hasActiveSuggestion => _activeSuggestion != null;
+  /// `true` if there is an active suggestion and undo delta is not empty;
+  /// `false` otherwise
+  bool get canUndo => _activeSuggestion?.undo.isNotEmpty == true;
 
   /// Perform detection of auto formats and apply changes to [document].
   ///
@@ -335,7 +336,7 @@ class _AutoTextDirection extends AutoFormat {
 
   bool _isBeforeEmptyLine(Operation next, String data) {
     final nextData = next.data;
-    return nextData is String ? nextData.startsWith('$data\n') : false;
+    return nextData is String ? nextData.startsWith('\n') : false;
   }
 
   bool _isInEmptyLine(Operation? previous, Operation next, String data) =>
@@ -348,6 +349,7 @@ class _AutoTextDirection extends AutoFormat {
     final documentDelta = document.toDelta();
     final iter = DeltaIterator(document.toDelta());
     final previous = iter.skip(position);
+    iter.skip(data.length);
     final next = iter.next();
 
     if (!_isInEmptyLine(previous, next, data)) return null;

--- a/packages/fleather/lib/src/widgets/controller.dart
+++ b/packages/fleather/lib/src/widgets/controller.dart
@@ -171,6 +171,8 @@ class FleatherController extends ChangeNotifier {
   // document; `false` otherwise
   bool _captureAutoFormatCancellationOrUndo(
       ParchmentDocument document, int position, int length, Object data) {
+    if (!_autoFormats.hasActiveSuggestion) return true;
+    
     if (_autoFormats.canUndo) {
       final isDeletionOfOneChar = data is String && data.isEmpty && length == 1;
       if (isDeletionOfOneChar) {

--- a/packages/fleather/lib/src/widgets/controller.dart
+++ b/packages/fleather/lib/src/widgets/controller.dart
@@ -171,7 +171,7 @@ class FleatherController extends ChangeNotifier {
   // document; `false` otherwise
   bool _captureAutoFormatCancellationOrUndo(
       ParchmentDocument document, int position, int length, Object data) {
-    if (!_autoFormats.hasActiveSuggestion) return true;
+    if (!_autoFormats.canUndo) return true;
 
     final isDeletionOfOneChar = data is String && data.isEmpty && length == 1;
     if (isDeletionOfOneChar) {

--- a/packages/fleather/lib/src/widgets/controller.dart
+++ b/packages/fleather/lib/src/widgets/controller.dart
@@ -171,17 +171,17 @@ class FleatherController extends ChangeNotifier {
   // document; `false` otherwise
   bool _captureAutoFormatCancellationOrUndo(
       ParchmentDocument document, int position, int length, Object data) {
-    if (!_autoFormats.canUndo) return true;
-
-    final isDeletionOfOneChar = data is String && data.isEmpty && length == 1;
-    if (isDeletionOfOneChar) {
-      // Undo if deleting 1 character after retain of auto-format
-      if (position == _autoFormats.undoPosition) {
-        final undoSelection = _autoFormats.undoActive(document);
-        if (undoSelection != null) {
-          _updateSelectionSilent(undoSelection, source: ChangeSource.local);
+    if (_autoFormats.canUndo) {
+      final isDeletionOfOneChar = data is String && data.isEmpty && length == 1;
+      if (isDeletionOfOneChar) {
+        // Undo if deleting 1 character after retain of auto-format
+        if (position == _autoFormats.undoPosition) {
+          final undoSelection = _autoFormats.undoActive(document);
+          if (undoSelection != null) {
+            _updateSelectionSilent(undoSelection, source: ChangeSource.local);
+          }
+          return false;
         }
-        return false;
       }
     }
     // Cancel active nevertheless

--- a/packages/fleather/lib/src/widgets/controller.dart
+++ b/packages/fleather/lib/src/widgets/controller.dart
@@ -172,7 +172,7 @@ class FleatherController extends ChangeNotifier {
   bool _captureAutoFormatCancellationOrUndo(
       ParchmentDocument document, int position, int length, Object data) {
     if (!_autoFormats.hasActiveSuggestion) return true;
-    
+
     if (_autoFormats.canUndo) {
       final isDeletionOfOneChar = data is String && data.isEmpty && length == 1;
       if (isDeletionOfOneChar) {

--- a/packages/fleather/test/widgets/autoformats_test.dart
+++ b/packages/fleather/test/widgets/autoformats_test.dart
@@ -45,7 +45,7 @@ void main() {
       ]);
       final performed = autoformats.run(document, 54, 'p');
       expect(performed, false);
-      expect(autoformats.canUndo, isFalse);
+      expect(autoformats.hasActiveSuggestion, isFalse);
     });
 
     test('Deleting at candidate position, undoes link formatting', () {
@@ -67,7 +67,7 @@ void main() {
       ]);
       autoformats.run(document, 54, ' ');
       autoformats.cancelActive();
-      expect(autoformats.canUndo, isFalse);
+      expect(autoformats.hasActiveSuggestion, isFalse);
     });
   });
 
@@ -138,7 +138,7 @@ void main() {
       ]);
       final performed = autoformats.run(document, 16, 'p');
       expect(performed, false);
-      expect(autoformats.canUndo, isFalse);
+      expect(autoformats.hasActiveSuggestion, isFalse);
     });
 
     test('Deleting at candidate position, undoes link formatting', () {
@@ -160,7 +160,7 @@ void main() {
       ]);
       autoformats.run(document, 54, ' ');
       autoformats.cancelActive();
-      expect(autoformats.canUndo, isFalse);
+      expect(autoformats.hasActiveSuggestion, isFalse);
     });
   });
 


### PR DESCRIPTION
It fixes two issues:

1. When users enters a character in an empty line with line style auto text direction is not working correctly
2. When auto format applies the same style the undo is an empty delta and applying it causes exception