### PR TITLE
Use framework context menu instead on browser context menu on web

### DIFF
--- a/packages/fleather/example/lib/main.dart
+++ b/packages/fleather/example/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:fleather/fleather.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:quill_delta/quill_delta.dart';
@@ -37,7 +38,14 @@ class _HomePageState extends State<HomePage> {
   @override
   void initState() {
     super.initState();
+    if (kIsWeb) BrowserContextMenu.disableContextMenu();
     _initController();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    if (kIsWeb) BrowserContextMenu.enableContextMenu();
   }
 
   Future<void> _initController() async {

--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -317,9 +317,6 @@ class _FleatherEditorState extends State<FleatherEditor>
   @override
   void initState() {
     super.initState();
-    if (kIsWeb) {
-      BrowserContextMenu.disableContextMenu();
-    }
     if (widget.editorKey == null) {
       _editorKey = GlobalKey<EditorState>();
     }
@@ -330,9 +327,6 @@ class _FleatherEditorState extends State<FleatherEditor>
   @override
   void dispose() {
     super.dispose();
-    if (kIsWeb) {
-      BrowserContextMenu.enableContextMenu();
-    }
   }
 
   static const Set<TargetPlatform> _mobilePlatforms = {
@@ -889,6 +883,14 @@ class RawEditorState extends EditorState
   /// is already shown, or when no text selection currently exists.
   @override
   bool showToolbar({createIfNull = false}) {
+    // Web is using native dom elements to enable clipboard functionality of the
+    // toolbar: copy, paste, select, cut. It might also provide additional
+    // functionality depending on the browser (such as translate). Due to this
+    // we should not show a Flutter toolbar for the editable text elements.
+    if (kIsWeb && BrowserContextMenu.enabled) {
+      return false;
+    }
+
     if (_selectionOverlay == null) {
       if (createIfNull) {
         _selectionOverlay = _createSelectionOverlay();

--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -317,11 +317,22 @@ class _FleatherEditorState extends State<FleatherEditor>
   @override
   void initState() {
     super.initState();
+    if (kIsWeb) {
+      BrowserContextMenu.disableContextMenu();
+    }
     if (widget.editorKey == null) {
       _editorKey = GlobalKey<EditorState>();
     }
     _selectionGestureDetectorBuilder =
         _FleatherEditorSelectionGestureDetectorBuilder(state: this);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    if (kIsWeb) {
+      BrowserContextMenu.enableContextMenu();
+    }
   }
 
   static const Set<TargetPlatform> _mobilePlatforms = {
@@ -878,14 +889,6 @@ class RawEditorState extends EditorState
   /// is already shown, or when no text selection currently exists.
   @override
   bool showToolbar({createIfNull = false}) {
-    // Web is using native dom elements to enable clipboard functionality of the
-    // toolbar: copy, paste, select, cut. It might also provide additional
-    // functionality depending on the browser (such as translate). Due to this
-    // we should not show a Flutter toolbar for the editable text elements.
-    if (kIsWeb) {
-      return false;
-    }
-
     if (_selectionOverlay == null) {
       if (createIfNull) {
         _selectionOverlay = _createSelectionOverlay();

--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -324,11 +324,6 @@ class _FleatherEditorState extends State<FleatherEditor>
         _FleatherEditorSelectionGestureDetectorBuilder(state: this);
   }
 
-  @override
-  void dispose() {
-    super.dispose();
-  }
-
   static const Set<TargetPlatform> _mobilePlatforms = {
     TargetPlatform.iOS,
     TargetPlatform.android


### PR DESCRIPTION
Use of browser context menu on web causes some issue that make it unusable. (see https://github.com/flutter/flutter/issues/134024)
This PR proposes to use the context menu provided by the framework instead