### PR TITLE
[web] Update HTML contentEditable with correct size and style

### DIFF
--- a/packages/fleather/lib/src/rendering/editable_text_line.dart
+++ b/packages/fleather/lib/src/rendering/editable_text_line.dart
@@ -19,7 +19,6 @@ enum TextLineSlot { leading, body }
 class RenderEditableTextLine extends RenderEditableBox {
   /// Creates new editable paragraph render box.
   RenderEditableTextLine({
-    // RenderEditableMetricsProvider child,
     required LineNode node,
     required EdgeInsetsGeometry padding,
     required TextDirection textDirection,
@@ -35,8 +34,6 @@ class RenderEditableTextLine extends RenderEditableBox {
     ui.BoxWidthStyle selectionWidthStyle = ui.BoxWidthStyle.tight,
     EdgeInsets floatingCursorAddedMargin =
         const EdgeInsets.fromLTRB(4, 4, 4, 5),
-//    TextRange promptRectRange,
-//    Color promptRectColor,
   })  : assert(padding.isNonNegative),
         _textDirection = textDirection,
         _padding = padding,

--- a/packages/fleather/lib/src/rendering/editor.dart
+++ b/packages/fleather/lib/src/rendering/editor.dart
@@ -167,6 +167,8 @@ class RenderEditor extends RenderEditableContainerBox
 
   ParchmentDocument _document;
 
+  ParchmentDocument get document => _document;
+
   set document(ParchmentDocument value) {
     if (_document == value) {
       return;
@@ -246,6 +248,8 @@ class RenderEditor extends RenderEditableContainerBox
   }
 
   double? _maxContentWidth;
+
+  double? get maxContentWidth => _maxContentWidth;
 
   set maxContentWidth(double? value) {
     if (_maxContentWidth == value) return;

--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -732,6 +732,8 @@ abstract class EditorState extends State<RawEditor>
 
   EditorTextSelectionOverlay? get selectionOverlay;
 
+  FleatherThemeData get themeData;
+
   /// Controls the floating cursor animation when it is released.
   /// The floating cursor is animated to merge with the regular cursor.
   AnimationController get floatingCursorResetController;
@@ -802,6 +804,9 @@ class RawEditorState extends EditorState
 
   // Theme
   late FleatherThemeData _themeData;
+
+  @override
+  FleatherThemeData get themeData => _themeData;
 
   // Cursors
   late CursorController _cursorController;
@@ -1366,6 +1371,7 @@ class RawEditorState extends EditorState
       TextSelection selection, SelectionChangedCause cause) {
     final oldSelection = widget.controller.selection;
     widget.controller.updateSelection(selection, source: ChangeSource.local);
+    updateTextInputConnectionStyle(selection.base);
 
     if (widget.selectionControls == null) {
       _selectionOverlay?.dispose();

--- a/packages/fleather/test/widgets/editor_input_client_mixin_deltas_test.dart
+++ b/packages/fleather/test/widgets/editor_input_client_mixin_deltas_test.dart
@@ -1,8 +1,11 @@
 import 'package:fleather/fleather.dart';
 import 'package:fleather/src/widgets/editor_input_client_mixin.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+
+import '../rendering/rendering_tools.dart';
 
 class MockRawEditor extends Mock implements RawEditor {
   @override
@@ -11,6 +14,23 @@ class MockRawEditor extends Mock implements RawEditor {
 }
 
 class MockEditorState extends Mock implements EditorState {
+  @override
+  RenderEditor renderEditor = RenderEditor(
+      document: ParchmentDocument.fromJson([
+        {'insert': 'Some text\n'}
+      ]),
+      textDirection: TextDirection.ltr,
+      hasFocus: true,
+      selection: const TextSelection.collapsed(offset: 0),
+      startHandleLayerLink: LayerLink(),
+      endHandleLayerLink: LayerLink(),
+      padding: EdgeInsets.zero,
+      cursorController: CursorController(
+          showCursor: ValueNotifier(true),
+          style: const CursorStyle(
+              color: Colors.black, backgroundColor: Colors.black),
+          tickerProvider: FakeTickerProvider()));
+
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
       super.toString();
@@ -33,32 +53,87 @@ class MockTextEditingValue extends Mock implements TextEditingValue {
   Map<String, dynamic> toJSON() => {};
 }
 
-void main() {
-  late MockRawEditorState editorState;
-  late RawEditor rawEditor;
-  late FleatherController controller;
-  final initialTextEditingValue = MockTextEditingValue();
+Matcher matchesMethodCall(String method, {dynamic args}) =>
+    _MatchesMethodCall(method,
+        arguments: args == null ? null : wrapMatcher(args));
 
+class _MatchesMethodCall extends Matcher {
+  const _MatchesMethodCall(this.name, {this.arguments});
+
+  final String name;
+  final Matcher? arguments;
+
+  @override
+  bool matches(dynamic item, Map<dynamic, dynamic> matchState) {
+    if (item is MethodCall && item.method == name) {
+      return arguments?.matches(item.arguments, matchState) ?? true;
+    }
+    return false;
+  }
+
+  @override
+  Description describe(Description description) {
+    final Description newDescription =
+        description.add('has method name: ').addDescriptionOf(name);
+    if (arguments != null) {
+      newDescription.add(' with arguments: ').addDescriptionOf(arguments);
+    }
+    return newDescription;
+  }
+}
+
+void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  setUp(() {
-    editorState = MockRawEditorState();
-    rawEditor = MockRawEditor();
-    controller = MockFleatherController();
-    when(() => editorState.widget).thenReturn(rawEditor);
-    when(() => editorState.textEditingValue)
-        .thenReturn(initialTextEditingValue);
-    when(() => rawEditor.controller).thenReturn(controller);
-    when(() => rawEditor.readOnly).thenReturn(false);
-    when(() => rawEditor.keyboardAppearance).thenReturn(Brightness.light);
-    when(() => rawEditor.textCapitalization)
-        .thenReturn(TextCapitalization.none);
-    when(() => controller.replaceText(any(), any(), any(),
-        selection: any(named: 'selection'))).thenReturn(null);
-  });
-
   group('updateEditingValueWithDeltas', () {
-    setUp(() => editorState.openConnectionIfNeeded());
+    late MockRawEditorState editorState;
+    late RawEditor rawEditor;
+    late FleatherController controller;
+    final initialTextEditingValue = MockTextEditingValue();
+
+    setUp(() {
+      editorState = MockRawEditorState();
+      rawEditor = MockRawEditor();
+      controller = MockFleatherController();
+      when(() => editorState.widget).thenReturn(rawEditor);
+      when(() => editorState.textEditingValue)
+          .thenReturn(initialTextEditingValue);
+      when(() => editorState.themeData).thenReturn(FleatherThemeData(
+          bold: const TextStyle(),
+          italic: const TextStyle(),
+          underline: const TextStyle(),
+          strikethrough: const TextStyle(),
+          inlineCode: InlineCodeThemeData(style: const TextStyle()),
+          link: const TextStyle(),
+          paragraph: TextBlockTheme(
+              style: const TextStyle(), spacing: const VerticalSpacing()),
+          heading1: TextBlockTheme(
+              style: const TextStyle(), spacing: const VerticalSpacing()),
+          heading2: TextBlockTheme(
+              style: const TextStyle(), spacing: const VerticalSpacing()),
+          heading3: TextBlockTheme(
+              style: const TextStyle(), spacing: const VerticalSpacing()),
+          heading4: TextBlockTheme(
+              style: const TextStyle(), spacing: const VerticalSpacing()),
+          heading5: TextBlockTheme(
+              style: const TextStyle(), spacing: const VerticalSpacing()),
+          heading6: TextBlockTheme(
+              style: const TextStyle(), spacing: const VerticalSpacing()),
+          lists: TextBlockTheme(
+              style: const TextStyle(), spacing: const VerticalSpacing()),
+          quote: TextBlockTheme(
+              style: const TextStyle(), spacing: const VerticalSpacing()),
+          code: TextBlockTheme(
+              style: const TextStyle(), spacing: const VerticalSpacing())));
+      when(() => rawEditor.controller).thenReturn(controller);
+      when(() => rawEditor.readOnly).thenReturn(false);
+      when(() => rawEditor.keyboardAppearance).thenReturn(Brightness.light);
+      when(() => rawEditor.textCapitalization)
+          .thenReturn(TextCapitalization.none);
+      when(() => controller.replaceText(any(), any(), any(),
+          selection: any(named: 'selection'))).thenReturn(null);
+      editorState.openConnectionIfNeeded();
+    });
 
     test('is readOnly or deltas are empty', () {
       when(() => rawEditor.readOnly).thenReturn(true);

--- a/packages/fleather/test/widgets/editor_input_client_mixin_test.dart
+++ b/packages/fleather/test/widgets/editor_input_client_mixin_test.dart
@@ -1,0 +1,252 @@
+import 'package:fleather/fleather.dart';
+import 'package:fleather/src/widgets/editor_input_client_mixin.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../testing.dart';
+
+void main() {
+  group('sets style to TextInputConnection', () {
+    final log = <TextInputConnectionStyle>[];
+
+    void bind(WidgetTester tester) {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.textInput, (MethodCall methodCall) async {
+        if (methodCall.method == 'TextInput.setStyle') {
+          final Map<String, dynamic> args =
+              methodCall.arguments as Map<String, dynamic>;
+          final fontFamily = args['fontFamily'];
+          final fontSize = args['fontSize'];
+          final fontWeightIndex = args['fontWeightIndex'];
+          final textAlignIndex = args['textAlignIndex'];
+          final textDirectionIndex = args['textDirectionIndex'];
+          final TextInputConnectionStyle style = TextInputConnectionStyle(
+              textStyle: TextStyle(
+                  fontFamily: fontFamily,
+                  fontSize: fontSize,
+                  fontWeight: fontWeightIndex != null
+                      ? FontWeight.values[fontWeightIndex]
+                      : null),
+              textAlign: textAlignIndex != null
+                  ? TextAlign.values[textAlignIndex]
+                  : TextAlign.left,
+              textDirection: textDirectionIndex != null
+                  ? TextDirection.values[textDirectionIndex]
+                  : TextDirection.ltr);
+          log.add(style);
+        }
+        return null;
+      });
+    }
+
+    setUp(() => log.clear());
+
+    testWidgets('sets style on position 0 by default', (tester) async {
+      bind(tester);
+      final document = ParchmentDocument.fromJson([
+        {'insert': 'some text\n'}
+      ]);
+      final editor = EditorSandBox(tester: tester, document: document);
+      await editor.pump();
+      await editor.tap();
+      tester.binding.scheduleWarmUpFrame();
+      expect(log.length, 1);
+      expect(
+          log.first,
+          const TextInputConnectionStyle(
+              textStyle: TextStyle(
+                  inherit: true,
+                  fontFamily: 'Roboto',
+                  fontSize: 16.0,
+                  fontWeight: FontWeight.w400),
+              textDirection: TextDirection.ltr,
+              textAlign: TextAlign.left));
+    });
+
+    testWidgets('changing selection updates text input connection style',
+        (tester) async {
+      bind(tester);
+      final document = ParchmentDocument.fromJson([
+        {'insert': 'Heading 1'},
+        {
+          'insert': '\n',
+          'attributes': {'heading': 1}
+        },
+        {'insert': 'Normal paragraph\n'},
+      ]);
+      final editor = EditorSandBox(tester: tester, document: document);
+      await editor.pump();
+      final context = tester.element(find.byType(RawEditor));
+      final themeData = FleatherThemeData.fallback(context);
+      await tester.tapAt(tester.getTopLeft(find.byType(FleatherEditor)) +
+          Offset(20, themeData.heading1.spacing.top));
+      tester.binding.scheduleWarmUpFrame();
+      expect(log.length, 1);
+      expect(
+          log.first,
+          TextInputConnectionStyle(
+              textStyle: TextStyle(
+                  inherit: true,
+                  fontFamily: 'Roboto',
+                  fontSize: themeData.heading1.style.fontSize,
+                  fontWeight: themeData.heading1.style.fontWeight),
+              textDirection: TextDirection.ltr,
+              textAlign: TextAlign.left));
+      log.clear();
+      final paragraphOffset = Offset(
+          20,
+          themeData.heading1.spacing.top +
+              (themeData.heading1.style.fontSize ?? 0) +
+              themeData.paragraph.spacing.top +
+              10);
+      await tester.tapAt(
+          tester.getTopLeft(find.byType(FleatherEditor)) + paragraphOffset);
+      tester.binding.scheduleWarmUpFrame();
+      expect(log.length, 1);
+      expect(
+          log.first,
+          TextInputConnectionStyle(
+              textStyle: TextStyle(
+                  inherit: true,
+                  fontFamily: 'Roboto',
+                  fontSize: themeData.paragraph.style.fontSize,
+                  fontWeight: themeData.paragraph.style.fontWeight),
+              textDirection: TextDirection.ltr,
+              textAlign: TextAlign.left));
+    });
+
+    testWidgets('sets style to TextInputConnection for all line/block styles',
+        (tester) async {
+      bind(tester);
+      final coveredAttributes = [
+        ParchmentAttribute.h2,
+        ParchmentAttribute.h3,
+        ParchmentAttribute.h4,
+        ParchmentAttribute.h5,
+        ParchmentAttribute.h6,
+        ParchmentAttribute.code,
+      ];
+      TextBlockTheme themeFromAttribute(
+          ParchmentAttribute attribute, FleatherThemeData themeData) {
+        final styles = {
+          ParchmentAttribute.h2: themeData.heading2,
+          ParchmentAttribute.h3: themeData.heading3,
+          ParchmentAttribute.h4: themeData.heading4,
+          ParchmentAttribute.h5: themeData.heading5,
+          ParchmentAttribute.h6: themeData.heading6,
+          ParchmentAttribute.code: themeData.code
+        };
+        return styles[attribute]!;
+      }
+
+      for (final attribute in coveredAttributes) {
+        final document = ParchmentDocument.fromJson([
+          {'insert': 'text that will be tapped'},
+          {
+            'insert': '\n',
+            'attributes': {attribute.key: attribute.value}
+          },
+        ]);
+        final editor = EditorSandBox(tester: tester, document: document);
+        await editor.pump();
+        await editor.tap();
+        final context = tester.element(find.byType(RawEditor));
+        final themeData = FleatherThemeData.fallback(context);
+        final themeDataItem = themeFromAttribute(attribute, themeData);
+        tester.binding.scheduleWarmUpFrame();
+        expect(log.length, 1);
+        expect(
+            log.first,
+            TextInputConnectionStyle(
+                textStyle: TextStyle(
+                    inherit: true,
+                    fontFamily: attribute == ParchmentAttribute.code
+                        ? 'Roboto Mono'
+                        : null,
+                    fontSize: themeDataItem.style.fontSize,
+                    fontWeight: themeDataItem.style.fontWeight),
+                textDirection: TextDirection.ltr,
+                textAlign: TextAlign.left));
+        log.clear();
+      }
+    });
+
+    testWidgets('sets style to TextInputConnection for RTL direction',
+        (tester) async {
+      bind(tester);
+      final document = ParchmentDocument.fromJson([
+        {'insert': 'text that will be tapped'},
+        {
+          'insert': '\n',
+          'attributes': {
+            ParchmentAttribute.rtl.key: ParchmentAttribute.rtl.value
+          }
+        },
+      ]);
+      final editor = EditorSandBox(tester: tester, document: document);
+      await editor.pump();
+      await editor.tap();
+      final context = tester.element(find.byType(RawEditor));
+      final themeData = FleatherThemeData.fallback(context);
+      tester.binding.scheduleWarmUpFrame();
+      expect(log.length, 1);
+      expect(
+          log.first,
+          TextInputConnectionStyle(
+              textStyle: TextStyle(
+                  inherit: true,
+                  fontFamily: 'Roboto',
+                  fontSize: themeData.paragraph.style.fontSize,
+                  fontWeight: themeData.paragraph.style.fontWeight),
+              textDirection: TextDirection.rtl,
+              textAlign: TextAlign.left));
+    });
+
+    testWidgets('sets style to TextInputConnection for all TextAlign',
+        (tester) async {
+      bind(tester);
+      final coveredAlignments = {
+        ParchmentAttribute.left: TextAlign.left,
+        ParchmentAttribute.justify: TextAlign.justify,
+        ParchmentAttribute.center: TextAlign.center,
+        ParchmentAttribute.right: TextAlign.right
+      };
+
+      for (final alignmentMapping in coveredAlignments.entries) {
+        final attribute = alignmentMapping.key;
+        final alignment = alignmentMapping.value;
+        final document = ParchmentDocument.fromJson([
+          {'insert': 'text that will be tapped'},
+          {
+            'insert': '\n',
+            'attributes': {attribute.key: attribute.value}
+          },
+        ]);
+        final editor = EditorSandBox(tester: tester, document: document);
+        await editor.pump();
+        if (alignment == TextAlign.right) {
+          await tester.tapAt(tester.getTopRight(find.byType(RawEditor)) +
+              const Offset(-20, 10));
+        } else {
+          await editor.tap();
+        }
+        final context = tester.element(find.byType(RawEditor));
+        final themeData = FleatherThemeData.fallback(context);
+        tester.binding.scheduleWarmUpFrame();
+        expect(log.length, 1);
+        expect(
+            log.first,
+            TextInputConnectionStyle(
+                textStyle: TextStyle(
+                    inherit: true,
+                    fontFamily: 'Roboto',
+                    fontSize: themeData.paragraph.style.fontSize,
+                    fontWeight: themeData.paragraph.style.fontWeight),
+                textDirection: TextDirection.ltr,
+                textAlign: alignment));
+        log.clear();
+      }
+    });
+  });
+}


### PR DESCRIPTION
The PR attempts to make proper use of the `TextInputConnection` API in order to better handle cursor movements on web browsers.

### Known issue: 
- "go to line end" sometimes moves cursor to start of next line within a same paragraph
- arrow up keydown from the first line of a paragraph will move to previous paragraph but not necessarily at the right position if paragraphs have different style