### PR TITLE
`getPositionAbove` handles correctly empty lines

### DIFF
--- a/packages/fleather/lib/src/rendering/editable_text_line.dart
+++ b/packages/fleather/lib/src/rendering/editable_text_line.dart
@@ -282,8 +282,13 @@ class RenderEditableTextLine extends RenderEditableBox {
   // Computes the line box height for the position.
   double _getLineHeightForPosition(TextPosition position) {
     final lineBoundary = getLineBoundary(position);
-    final boxes = body!.getBoxesForSelection(TextSelection(
+    var boxes = body!.getBoxesForSelection(TextSelection(
         baseOffset: lineBoundary.start, extentOffset: lineBoundary.end));
+    // Boxes are empty for an empty line (containing only \n)
+    if (boxes.isEmpty && lineBoundary == const TextRange.collapsed(0)) {
+      boxes = body!.getBoxesForSelection(TextSelection(
+          baseOffset: lineBoundary.start, extentOffset: lineBoundary.end + 1));
+    }
     return boxes.fold(0, (v, e) => math.max(v, e.toRect().height));
   }
 

--- a/packages/fleather/test/widgets/editor_test.dart
+++ b/packages/fleather/test/widgets/editor_test.dart
@@ -677,7 +677,7 @@ void main() {
               'color': '0xFF2196F3'
             }
           },
-          {'insert': '\n'},
+          {'insert': '\n\n'},
         ]);
         final editor = EditorSandBox(
           tester: tester,
@@ -705,6 +705,9 @@ void main() {
         await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
         expect(editor.selection,
             const TextSelection.collapsed(offset: text.length));
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        expect(editor.selection, const TextSelection.collapsed(offset: 50));
       });
 
       testWidgets(


### PR DESCRIPTION
Fixes #231 