### PR TITLE
Downgrade intl version to 0.18.1

### DIFF
--- a/packages/fleather/pubspec.yaml
+++ b/packages/fleather/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
   collection: ^1.16.0
   quill_delta: ^3.0.0-nullsafety.2
-  intl: ^0.19.0
+  intl: ^0.18.1
   parchment: ^1.13.0
 
 dependency_overrides:


### PR DESCRIPTION
This fixes dependency resolve issue in projects depending on `flutter_localizations`:

```console
Resolving dependencies...
Note: intl is pinned to version 0.18.1 by flutter_localizations from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because X depends on flutter_localizations from sdk which depends on intl 0.18.1, intl 0.18.1 is required.
So, because X depends on intl ^0.19.0, version solving failed.
exit code 1
```