### PR TITLE
Enhancing FleatherToolbar with Customizable Heading Labels for User-Guided Text Formatting

### DIFF
--- a/packages/fleather/lib/src/widgets/editor_toolbar.dart
+++ b/packages/fleather/lib/src/widgets/editor_toolbar.dart
@@ -576,14 +576,23 @@ class SelectHeadingButton extends StatefulWidget {
   State<SelectHeadingButton> createState() => _SelectHeadingButtonState();
 }
 
+// Global heading overrides to allow setting from the editor toolbar
+String normalLabelOverride = 'Normal';
+String heading1LabelOverride = 'Heading 1';
+String heading2LabelOverride = 'Heading 2';
+String heading3LabelOverride = 'Heading 3';
+String heading4LabelOverride = 'Heading 4';
+String heading5LabelOverride = 'Heading 5';
+String heading6LabelOverride = 'Heading 6';
+
 final _headingToText = {
-  ParchmentAttribute.heading.unset: 'Normal',
-  ParchmentAttribute.heading.level1: 'Heading 1',
-  ParchmentAttribute.heading.level2: 'Heading 2',
-  ParchmentAttribute.heading.level3: 'Heading 3',
-  ParchmentAttribute.heading.level4: 'Heading 4',
-  ParchmentAttribute.heading.level5: 'Heading 5',
-  ParchmentAttribute.heading.level6: 'Heading 6',
+  ParchmentAttribute.heading.unset: normalLabelOverride,
+  ParchmentAttribute.heading.level1: heading1LabelOverride,
+  ParchmentAttribute.heading.level2: heading2LabelOverride,
+  ParchmentAttribute.heading.level3: heading3LabelOverride,
+  ParchmentAttribute.heading.level4: heading4LabelOverride,
+  ParchmentAttribute.heading.level5: heading5LabelOverride,
+  ParchmentAttribute.heading.level6: heading6LabelOverride,
 };
 
 class _SelectHeadingButtonState extends State<SelectHeadingButton> {
@@ -857,7 +866,27 @@ class FleatherToolbar extends StatefulWidget implements PreferredSizeWidget {
     List<Widget> leading = const <Widget>[],
     List<Widget> trailing = const <Widget>[],
     bool hideAlignment = false,
+
+    // New optional overrides for heading labels
+    String normalLabel = 'Normal',
+    String heading1Label = 'Heading 1',
+    String heading2Label = 'Heading 2',
+    String heading3Label = 'Heading 3',
+    String heading4Label = 'Heading 4',
+    String heading5Label = 'Heading 5',
+    String heading6Label = 'Heading 6',
+
   }) {
+
+    // Set heading overrides
+    normalLabelOverride = normalLabel;
+    heading1LabelOverride = heading1Label;
+    heading2LabelOverride = heading2Label;
+    heading3LabelOverride = heading3Label;
+    heading4LabelOverride = heading4Label;
+    heading5LabelOverride = heading5Label;
+    heading6LabelOverride = heading6Label;
+
     Widget backgroundColorBuilder(context, value) => Column(
           mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.center,

--- a/packages/fleather/lib/src/widgets/theme.dart
+++ b/packages/fleather/lib/src/widgets/theme.dart
@@ -317,6 +317,7 @@ class FleatherThemeData {
       heading3: other.heading3,
       heading4: other.heading4,
       heading5: other.heading5,
+      heading6: other.heading6,
       lists: other.lists,
       quote: other.quote,
       code: other.code,


### PR DESCRIPTION
First of all, Thanks for the amazing work on this package. 

I propose an enhancement to the FleatherToolbar class to support customizable heading labels. This feature introduces optional parameters: normalLabel, heading1Label, heading2Label, heading3Label, heading4Label, heading5Label, and heading6Label. These parameters allow for the customization of toolbar heading labels, facilitating user guidance in text formatting, such as preset alert text formats. The implementation updates the _headingToText map to utilize these parameters, offering a flexible approach to managing text input formats. This addition aims to improve user experience by enabling more descriptive and context-specific toolbar labels.

I think this would be a good addition with minimal impact but improving the overall flexibility of the package

Edit: I'm not so used to pull requests so my other fix was also included with this one.