### PR TITLE
Add multiple links support to markdown codecs

### DIFF
--- a/packages/parchment/lib/src/codecs/markdown.dart
+++ b/packages/parchment/lib/src/codecs/markdown.dart
@@ -35,9 +35,7 @@ class _ParchmentMarkdownDecoder extends Converter<String, ParchmentDocument> {
     r'(`(?<inline_code_text>.+?)`)',
   );
 
-  // as per https://www.michaelperrin.fr/blog/2019/02/advanced-regular-expressions
-  static final _linkRegExp =
-      RegExp(r'\[(?<text>.+)\]\((?<url>[^ ]+)(?: "(?<title>.+)")?\)');
+  static final _linkRegExp = RegExp(r'\[([^\]]+)\]\(([^)]+)\)');
   static final _ulRegExp = RegExp(r'^( *)\* +(.*)');
   static final _olRegExp = RegExp(r'^( *)\d+[.)] +(.*)');
   static final _clRegExp = RegExp(r'^( *)- +\[( |x|X)\] +(.*)');

--- a/packages/parchment/lib/src/codecs/markdown.dart
+++ b/packages/parchment/lib/src/codecs/markdown.dart
@@ -35,7 +35,7 @@ class _ParchmentMarkdownDecoder extends Converter<String, ParchmentDocument> {
     r'(`(?<inline_code_text>.+?)`)',
   );
 
-  static final _linkRegExp = RegExp(r'\[([^\]]+)\]\(([^)]+)\)');
+  static final _linkRegExp = RegExp(r'\[(.+?)\]\(([^)]+)\)');
   static final _ulRegExp = RegExp(r'^( *)\* +(.*)');
   static final _olRegExp = RegExp(r'^( *)\d+[.)] +(.*)');
   static final _clRegExp = RegExp(r'^( *)- +\[( |x|X)\] +(.*)');

--- a/packages/parchment/test/codecs/markdown_test.dart
+++ b/packages/parchment/test/codecs/markdown_test.dart
@@ -225,6 +225,23 @@ void main() {
       expect(andBack, markdown);
     });
 
+    test('double link', () {
+      final markdown =
+          'This **house** is a [circus](https://github.com) and [home](https://github.com)\n\n';
+      final document = parchmentMarkdown.decode(markdown);
+      final delta = document.toDelta();
+
+      expect(delta.elementAt(3).data, 'circus');
+      expect(delta.elementAt(3).attributes?['b'], null);
+      expect(delta.elementAt(3).attributes?['a'], 'https://github.com');
+
+      expect(delta.elementAt(5).data, 'home');
+      expect(delta.elementAt(5).attributes?['a'], 'https://github.com');
+
+      final andBack = parchmentMarkdown.encode(document);
+      expect(andBack, markdown);
+    });
+
     test('style around link', () {
       final markdown =
           'This **house** is a **[circus](https://github.com)**\n\n';

--- a/packages/parchment/test/codecs/markdown_test.dart
+++ b/packages/parchment/test/codecs/markdown_test.dart
@@ -242,6 +242,23 @@ void main() {
       expect(andBack, markdown);
     });
 
+    test('complex link', () {
+      final markdown =
+          'This a complex link [1[2(3) 4]5 6](https://github.com/[abc]) and [normal one](https://github.com)\n\n';
+      final document = parchmentMarkdown.decode(markdown);
+      final delta = document.toDelta();
+
+      expect(delta.elementAt(1).data, '1[2(3) 4]5 6');
+      expect(delta.elementAt(1).attributes?['b'], null);
+      expect(delta.elementAt(1).attributes?['a'], 'https://github.com/[abc]');
+
+      expect(delta.elementAt(3).data, 'normal one');
+      expect(delta.elementAt(3).attributes?['a'], 'https://github.com');
+
+      final andBack = parchmentMarkdown.encode(document);
+      expect(andBack, markdown);
+    });
+
     test('style around link', () {
       final markdown =
           'This **house** is a **[circus](https://github.com)**\n\n';


### PR DESCRIPTION
Not sure if you want to merge this or not since the new link regex does not support having brackets inside of link urls etc. It does support multiple links however which in my project was more important. Added a test as an example of a markdown string with two links that the previous regex could not parse.