### PR TITLE
Enable auto correct

### DIFF
--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -155,6 +155,11 @@ class FleatherEditor extends StatefulWidget {
   /// Defaults to `false`. Must not be `null`.
   final bool readOnly;
 
+  /// Whether to enable autocorrection.
+  ///
+  /// Defaults to `true`.
+  final bool autocorrect;
+
   /// Whether to enable user interface affordances for changing the
   /// text selection.
   ///
@@ -283,6 +288,7 @@ class FleatherEditor extends StatefulWidget {
     this.autofocus = false,
     this.showCursor = true,
     this.readOnly = false,
+    this.autocorrect = true,
     this.enableInteractiveSelection = true,
     this.minHeight,
     this.maxHeight,
@@ -551,6 +557,7 @@ class RawEditor extends StatefulWidget {
     this.autofocus = false,
     bool? showCursor,
     this.readOnly = false,
+    this.autocorrect = true,
     this.enableInteractiveSelection = true,
     this.minHeight,
     this.maxHeight,
@@ -601,6 +608,11 @@ class RawEditor extends StatefulWidget {
   ///
   /// Defaults to false. Must not be null.
   final bool readOnly;
+
+  /// Whether to enable autocorrection.
+  ///
+  /// Defaults to `true`.
+  final bool autocorrect;
 
   /// Callback which is triggered when the user wants to open a URL from
   /// a link in the document.

--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -457,6 +457,7 @@ class _FleatherEditorState extends State<FleatherEditor>
       scrollable: widget.scrollable,
       padding: widget.padding,
       autofocus: widget.autofocus,
+      autocorrect: widget.autocorrect,
       showCursor: widget.showCursor,
       readOnly: widget.readOnly,
       enableInteractiveSelection: widget.enableInteractiveSelection,

--- a/packages/fleather/lib/src/widgets/editor_input_client_mixin.dart
+++ b/packages/fleather/lib/src/widgets/editor_input_client_mixin.dart
@@ -57,7 +57,7 @@ mixin RawEditorStateTextInputClientMixin on EditorState
           inputType: TextInputType.multiline,
           readOnly: widget.readOnly,
           obscureText: false,
-          autocorrect: true,
+          autocorrect: widget.autocorrect,
           enableDeltaModel: true,
           inputAction: TextInputAction.newline,
           keyboardAppearance: widget.keyboardAppearance,

--- a/packages/fleather/lib/src/widgets/editor_input_client_mixin.dart
+++ b/packages/fleather/lib/src/widgets/editor_input_client_mixin.dart
@@ -57,7 +57,7 @@ mixin RawEditorStateTextInputClientMixin on EditorState
           inputType: TextInputType.multiline,
           readOnly: widget.readOnly,
           obscureText: false,
-          autocorrect: false,
+          autocorrect: true,
           enableDeltaModel: true,
           inputAction: TextInputAction.newline,
           keyboardAppearance: widget.keyboardAppearance,

--- a/packages/fleather/lib/src/widgets/field.dart
+++ b/packages/fleather/lib/src/widgets/field.dart
@@ -65,6 +65,11 @@ class FleatherField extends StatefulWidget {
   /// Defaults to `false`. Must not be `null`.
   final bool readOnly;
 
+  /// Whether to enable autocorrection.
+  ///
+  /// Defaults to `true`.
+  final bool autocorrect;
+
   /// Whether to enable user interface affordances for changing the
   /// text selection.
   ///
@@ -175,6 +180,7 @@ class FleatherField extends StatefulWidget {
     this.autofocus = false,
     this.showCursor = true,
     this.readOnly = false,
+    this.autocorrect = true,
     this.enableInteractiveSelection = true,
     this.minHeight,
     this.maxHeight,
@@ -245,6 +251,7 @@ class _FleatherFieldState extends State<FleatherField> {
       autofocus: widget.autofocus,
       showCursor: widget.showCursor,
       readOnly: widget.readOnly,
+      autocorrect: widget.autocorrect,
       enableInteractiveSelection: widget.enableInteractiveSelection,
       minHeight: widget.minHeight,
       maxHeight: widget.maxHeight,

--- a/packages/fleather/test/widgets/editor_input_client_mixin_deltas_test.dart
+++ b/packages/fleather/test/widgets/editor_input_client_mixin_deltas_test.dart
@@ -127,6 +127,7 @@ void main() {
               style: const TextStyle(), spacing: const VerticalSpacing())));
       when(() => rawEditor.controller).thenReturn(controller);
       when(() => rawEditor.readOnly).thenReturn(false);
+      when(() => rawEditor.autocorrect).thenReturn(true);
       when(() => rawEditor.keyboardAppearance).thenReturn(Brightness.light);
       when(() => rawEditor.textCapitalization)
           .thenReturn(TextCapitalization.none);

--- a/packages/fleather/test/widgets/editor_input_client_mixin_test.dart
+++ b/packages/fleather/test/widgets/editor_input_client_mixin_test.dart
@@ -298,4 +298,29 @@ void main() {
       }
     });
   });
+
+  group('send editor options to TextInputConnection', () {
+    testWidgets('send autocorrect option', (tester) async {
+      Map<String, dynamic>? textInputClientProperties;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.textInput, (MethodCall methodCall) async {
+        if (methodCall.method == 'TextInput.setClient') {
+          textInputClientProperties = methodCall.arguments[1];
+        }
+        return null;
+      });
+
+      final editor =
+          EditorSandBox(tester: tester, document: ParchmentDocument());
+      await editor.pump();
+      await editor.tap();
+      tester.binding.scheduleWarmUpFrame();
+      await tester.pumpAndSettle();
+
+      expect(
+        textInputClientProperties?['autocorrect'],
+        true,
+      );
+    });
+  });
 }


### PR DESCRIPTION
I thought it would be a major undertaking, but after some research it turns out toggling the autocorrect flag was enough. Is there a reason this was turned off or can it be enabled? Auto correct was one of the main reasons that made me still reach for Apple Notes at times.

Note that I'm using Google Keyboard in the attached demo and auto correct also worked when I tried with SwiftKey. I could not get it to work with the default iOS keyboard (not in English nor Swedish). Any thoughts on that? My guess it is some kind of locale setting either on my device or with the Fleather editor somehow.

https://github.com/fleather-editor/fleather/assets/3586691/efdff54c-34a7-489b-9a6f-68955c456495

