### PR TITLE
Support inline markdown shortcuts

### DIFF
--- a/packages/fleather/lib/src/widgets/autoformats.dart
+++ b/packages/fleather/lib/src/widgets/autoformats.dart
@@ -210,7 +210,8 @@ class _MarkdownInlineShortcuts extends AutoFormat {
             change: change,
             undo: undo,
             undoPositionCandidate: position - (rule.length * 2),
-            selection: TextSelection.collapsed(offset: position - (rule.length * 2) + 1),
+            selection: TextSelection.collapsed(
+                offset: position - (rule.length * 2) + 1),
             undoSelection: TextSelection.collapsed(offset: position + 1),
           );
         }

--- a/packages/fleather/lib/src/widgets/autoformats.dart
+++ b/packages/fleather/lib/src/widgets/autoformats.dart
@@ -210,7 +210,7 @@ class _MarkdownInlineShortcuts extends AutoFormat {
             change: change,
             undo: undo,
             undoPositionCandidate: position - (rule.length * 2),
-            selection: TextSelection.collapsed(offset: position - rule.length),
+            selection: TextSelection.collapsed(offset: position - (rule.length * 2) + 1),
             undoSelection: TextSelection.collapsed(offset: position + 1),
           );
         }

--- a/packages/fleather/lib/src/widgets/autoformats.dart
+++ b/packages/fleather/lib/src/widgets/autoformats.dart
@@ -32,7 +32,8 @@ class AutoFormats {
   factory AutoFormats.fallback() {
     return AutoFormats(autoFormats: [
       const _AutoFormatLinks(),
-      const _MarkdownShortCuts(),
+      const _MarkdownInlineShortcuts(),
+      const _MarkdownLineShortcuts(),
       const _AutoTextDirection(),
     ]);
   }
@@ -165,8 +166,63 @@ class _AutoFormatLinks extends AutoFormat {
   }
 }
 
+// Replaces certain Markdown shortcuts with actual inline styles.
+class _MarkdownInlineShortcuts extends AutoFormat {
+  static final rules = <String, ParchmentAttribute>{
+    '**': ParchmentAttribute.bold,
+    '*': ParchmentAttribute.italic,
+    '`': ParchmentAttribute.inlineCode,
+    '~~': ParchmentAttribute.strikethrough,
+  };
+
+  const _MarkdownInlineShortcuts();
+
+  @override
+  AutoFormatResult? apply(
+      ParchmentDocument document, int position, String data) {
+    if (data != ' ' && data != '\n') return null;
+
+    final documentDelta = document.toDelta();
+    final iter = DeltaIterator(documentDelta);
+    final previous = iter.skip(position);
+    // No previous operation means nothing to analyze.
+    if (previous == null || previous.data is! String) return null;
+    final previousText = previous.data as String;
+    if (previousText.isEmpty) return null;
+
+    final candidate = previousText.split('\n').last;
+
+    for (final String rule in rules.keys) {
+      if (candidate.endsWith(rule)) {
+        final lastOffset = candidate.lastIndexOf(rule);
+        final startOffset =
+            candidate.substring(0, lastOffset).lastIndexOf(rule);
+        final contentLength = lastOffset - startOffset - rule.length;
+        if (startOffset != -1 && contentLength > 0) {
+          final change = Delta()
+            ..retain(position - candidate.length + startOffset)
+            ..delete(rule.length)
+            ..retain(contentLength, {...rules[rule]!.toJson()})
+            ..delete(rule.length);
+          final undo = change.invert(documentDelta);
+          document.compose(change, ChangeSource.local);
+          return AutoFormatResult(
+            change: change,
+            undo: undo,
+            undoPositionCandidate: position - (rule.length * 2),
+            selection: TextSelection.collapsed(offset: position - rule.length),
+            undoSelection: TextSelection.collapsed(offset: position + 1),
+          );
+        }
+      }
+    }
+
+    return null;
+  }
+}
+
 // Replaces certain Markdown shortcuts with actual line or block styles.
-class _MarkdownShortCuts extends AutoFormat {
+class _MarkdownLineShortcuts extends AutoFormat {
   static final rules = <String, ParchmentAttribute>{
     '-': ParchmentAttribute.block.bulletList,
     '*': ParchmentAttribute.block.bulletList,
@@ -180,7 +236,7 @@ class _MarkdownShortCuts extends AutoFormat {
     '###': ParchmentAttribute.h3,
   };
 
-  const _MarkdownShortCuts();
+  const _MarkdownLineShortcuts();
 
   String? _getLinePrefix(DeltaIterator iter, int index) {
     final prefixOps = skipToLineAt(iter, index);

--- a/packages/fleather/test/widgets/autoformats_test.dart
+++ b/packages/fleather/test/widgets/autoformats_test.dart
@@ -132,6 +132,58 @@ void main() {
           ParchmentAttribute.block.code.value);
     });
 
+    test('Detects italic shortcut', () {
+      final document = ParchmentDocument.fromJson([
+        {'insert': 'Some long text\n**Test*that continues\n'}
+      ]);
+      final performed = autoformats.run(document, 22, ' ');
+      expect(performed, isTrue);
+      expect(autoformats.selection, const TextSelection.collapsed(offset: 21));
+      final attributes = document.toDelta().toList()[1].attributes;
+      expect(attributes![ParchmentAttribute.italic.key], isTrue);
+    });
+
+    test('Detects bold shortcut', () {
+      final document = ParchmentDocument.fromJson([
+        {'insert': 'Some long text\n**Test**that continues\n'}
+      ]);
+      final performed = autoformats.run(document, 23, ' ');
+      expect(performed, isTrue);
+      expect(autoformats.selection, const TextSelection.collapsed(offset: 20));
+      final attributes = document.toDelta().toList()[1].attributes;
+      expect(attributes![ParchmentAttribute.bold.key], isTrue);
+    });
+
+    test('Detects inline code shortcut', () {
+      const text = 'Some long text\n`Test`that continues\n';
+      final document = ParchmentDocument.fromJson([
+        {'insert': text}
+      ]);
+      final performed = autoformats.run(document, 21, ' ');
+      expect(performed, isTrue);
+      expect(autoformats.selection, const TextSelection.collapsed(offset: 20));
+      final attributes = document.toDelta().toList()[1].attributes;
+      expect(attributes![ParchmentAttribute.inlineCode.key], isTrue);
+      final undoSelection = autoformats.undoActive(document);
+      expect(undoSelection, const TextSelection.collapsed(offset: 22));
+      expect(document.toDelta().first.data, text);
+    });
+
+    test('Detects strikethrough shortcut', () {
+      const text = 'Some long text\n~~Test~~that continues\n';
+      final document = ParchmentDocument.fromJson([
+        {'insert': text}
+      ]);
+      final performed = autoformats.run(document, 23, '\n');
+      expect(performed, isTrue);
+      expect(autoformats.selection, const TextSelection.collapsed(offset: 20));
+      final attributes = document.toDelta().toList()[1].attributes;
+      expect(attributes![ParchmentAttribute.strikethrough.key], isTrue);
+      final undoSelection = autoformats.undoActive(document);
+      expect(undoSelection, const TextSelection.collapsed(offset: 24));
+      expect(document.toDelta().first.data, text);
+    });
+
     test('No trigger of detection if inserting other than space', () {
       final document = ParchmentDocument.fromJson([
         {'insert': 'Some long text\n* \nthat continues\n'}


### PR DESCRIPTION
Fixes #355 by adding markdown shortcuts for bold, italic, inline code and strikethrough. Looks like underline isn't a standard attribute in [markdown](https://www.markdownguide.org/cheat-sheet/).

- [ ] Add tests