### PR TITLE
feature: enanble custom TextSelectionControls

### DIFF
--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -286,6 +286,8 @@ class FleatherEditor extends StatefulWidget {
 
   final GlobalKey<EditorState>? editorKey;
 
+  final TextSelectionControls? textSelectionControls;
+
   const FleatherEditor({
     super.key,
     required this.controller,
@@ -314,6 +316,7 @@ class FleatherEditor extends StatefulWidget {
     this.contextMenuBuilder = defaultContextMenuBuilder,
     this.embedBuilder = defaultFleatherEmbedBuilder,
     this.linkActionPickerDelegate = defaultLinkActionPickerDelegate,
+    this.textSelectionControls
   });
 
   @override
@@ -412,10 +415,11 @@ class _FleatherEditorState extends State<FleatherEditor>
 
     final keyboardAppearance = widget.keyboardAppearance ?? theme.brightness;
 
+ 
     switch (theme.platform) {
       case TargetPlatform.iOS:
         final cupertinoTheme = CupertinoTheme.of(context);
-        textSelectionControls = cupertinoTextSelectionControls;
+        textSelectionControls = widget.textSelectionControls ?? cupertinoTextSelectionControls;
         paintCursorAboveText = true;
         cursorOpacityAnimates = true;
         cursorColor = selectionTheme.cursorColor ?? cupertinoTheme.primaryColor;
@@ -428,7 +432,7 @@ class _FleatherEditorState extends State<FleatherEditor>
 
       case TargetPlatform.macOS:
         final CupertinoThemeData cupertinoTheme = CupertinoTheme.of(context);
-        textSelectionControls = cupertinoDesktopTextSelectionControls;
+        textSelectionControls = widget.textSelectionControls ?? cupertinoDesktopTextSelectionControls;
         paintCursorAboveText = true;
         cursorOpacityAnimates = false;
         cursorColor = selectionTheme.cursorColor ?? cupertinoTheme.primaryColor;
@@ -441,7 +445,7 @@ class _FleatherEditorState extends State<FleatherEditor>
 
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
-        textSelectionControls = materialTextSelectionControls;
+        textSelectionControls = widget.textSelectionControls ?? materialTextSelectionControls;
         paintCursorAboveText = false;
         cursorOpacityAnimates = false;
         cursorColor = selectionTheme.cursorColor ?? theme.colorScheme.primary;
@@ -451,7 +455,7 @@ class _FleatherEditorState extends State<FleatherEditor>
 
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        textSelectionControls = desktopTextSelectionControls;
+        textSelectionControls = widget.textSelectionControls ?? desktopTextSelectionControls;
         paintCursorAboveText = false;
         cursorOpacityAnimates = false;
         cursorColor = selectionTheme.cursorColor ?? theme.colorScheme.primary;

--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -288,36 +288,35 @@ class FleatherEditor extends StatefulWidget {
 
   final TextSelectionControls? textSelectionControls;
 
-  const FleatherEditor({
-    super.key,
-    required this.controller,
-    this.editorKey,
-    this.focusNode,
-    this.scrollController,
-    this.scrollable = true,
-    this.padding = EdgeInsets.zero,
-    this.autofocus = false,
-    this.showCursor = true,
-    this.readOnly = false,
-    this.autocorrect = true,
-    this.enableSuggestions = true,
-    this.enableInteractiveSelection = true,
-    this.minHeight,
-    this.maxHeight,
-    this.maxContentWidth,
-    this.expands = false,
-    this.textCapitalization = TextCapitalization.sentences,
-    this.keyboardAppearance,
-    this.scrollPhysics,
-    this.onLaunchUrl,
-    this.spellCheckConfiguration,
-    this.clipboardManager = const PlainTextClipboardManager(),
-    this.clipboardStatus,
-    this.contextMenuBuilder = defaultContextMenuBuilder,
-    this.embedBuilder = defaultFleatherEmbedBuilder,
-    this.linkActionPickerDelegate = defaultLinkActionPickerDelegate,
-    this.textSelectionControls
-  });
+  const FleatherEditor(
+      {super.key,
+      required this.controller,
+      this.editorKey,
+      this.focusNode,
+      this.scrollController,
+      this.scrollable = true,
+      this.padding = EdgeInsets.zero,
+      this.autofocus = false,
+      this.showCursor = true,
+      this.readOnly = false,
+      this.autocorrect = true,
+      this.enableSuggestions = true,
+      this.enableInteractiveSelection = true,
+      this.minHeight,
+      this.maxHeight,
+      this.maxContentWidth,
+      this.expands = false,
+      this.textCapitalization = TextCapitalization.sentences,
+      this.keyboardAppearance,
+      this.scrollPhysics,
+      this.onLaunchUrl,
+      this.spellCheckConfiguration,
+      this.clipboardManager = const PlainTextClipboardManager(),
+      this.clipboardStatus,
+      this.contextMenuBuilder = defaultContextMenuBuilder,
+      this.embedBuilder = defaultFleatherEmbedBuilder,
+      this.linkActionPickerDelegate = defaultLinkActionPickerDelegate,
+      this.textSelectionControls});
 
   @override
   State<FleatherEditor> createState() => _FleatherEditorState();
@@ -415,11 +414,11 @@ class _FleatherEditorState extends State<FleatherEditor>
 
     final keyboardAppearance = widget.keyboardAppearance ?? theme.brightness;
 
- 
     switch (theme.platform) {
       case TargetPlatform.iOS:
         final cupertinoTheme = CupertinoTheme.of(context);
-        textSelectionControls = widget.textSelectionControls ?? cupertinoTextSelectionControls;
+        textSelectionControls =
+            widget.textSelectionControls ?? cupertinoTextSelectionControls;
         paintCursorAboveText = true;
         cursorOpacityAnimates = true;
         cursorColor = selectionTheme.cursorColor ?? cupertinoTheme.primaryColor;
@@ -432,7 +431,8 @@ class _FleatherEditorState extends State<FleatherEditor>
 
       case TargetPlatform.macOS:
         final CupertinoThemeData cupertinoTheme = CupertinoTheme.of(context);
-        textSelectionControls = widget.textSelectionControls ?? cupertinoDesktopTextSelectionControls;
+        textSelectionControls = widget.textSelectionControls ??
+            cupertinoDesktopTextSelectionControls;
         paintCursorAboveText = true;
         cursorOpacityAnimates = false;
         cursorColor = selectionTheme.cursorColor ?? cupertinoTheme.primaryColor;
@@ -445,7 +445,8 @@ class _FleatherEditorState extends State<FleatherEditor>
 
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
-        textSelectionControls = widget.textSelectionControls ?? materialTextSelectionControls;
+        textSelectionControls =
+            widget.textSelectionControls ?? materialTextSelectionControls;
         paintCursorAboveText = false;
         cursorOpacityAnimates = false;
         cursorColor = selectionTheme.cursorColor ?? theme.colorScheme.primary;
@@ -455,7 +456,8 @@ class _FleatherEditorState extends State<FleatherEditor>
 
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        textSelectionControls = widget.textSelectionControls ?? desktopTextSelectionControls;
+        textSelectionControls =
+            widget.textSelectionControls ?? desktopTextSelectionControls;
         paintCursorAboveText = false;
         cursorOpacityAnimates = false;
         cursorColor = selectionTheme.cursorColor ?? theme.colorScheme.primary;

--- a/packages/fleather/test/widgets/editor_text_selection_controllers_test.dart
+++ b/packages/fleather/test/widgets/editor_text_selection_controllers_test.dart
@@ -1,0 +1,89 @@
+import 'dart:math' as math;
+
+import 'package:fleather/fleather.dart';
+import 'package:fleather/src/widgets/editor_input_client_mixin.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import '../testing.dart';
+
+class MyTextSelectionHandle extends StatefulWidget {
+  final Size size;
+  const MyTextSelectionHandle(
+      {super.key, required this.size});
+
+  @override
+  State<StatefulWidget> createState() {
+    return MyTextSelectionHandleState();
+  }
+}
+
+class MyTextSelectionHandleState
+    extends State<MyTextSelectionHandle> {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: widget.size.width,
+      height: widget.size.height,
+      color: Colors.red,
+    );
+  }
+}
+
+class MyTextSelectionControllers
+    extends MaterialTextSelectionControls {
+  final Size size;
+  MyTextSelectionControllers(this.size);
+
+  @override
+  Widget buildHandle(BuildContext context,
+      TextSelectionHandleType type, double textHeight,
+      [VoidCallback? onTap]) {
+    final Widget handle = MyTextSelectionHandle(
+      size: size,
+    );
+
+    return switch (type) {
+      TextSelectionHandleType.left => Transform.rotate(
+          angle: math.pi / 2.0,
+          child: handle), // points up-right
+      TextSelectionHandleType.right =>
+        handle, // points up-left
+      TextSelectionHandleType.collapsed => Transform.rotate(
+          angle: math.pi / 4.0, child: handle), // points up
+    };
+  }
+}
+
+void main() {
+  group('CustomTextSelectionControllers', () { 
+ 
+    testWidgets('set customTextSelectionControllers',
+        (tester) async { 
+      final document = ParchmentDocument.fromJson([
+        {'insert': 'some text\n'}
+      ]);
+      FleatherController controller =
+          FleatherController(document: document);
+      FocusNode focusNode = FocusNode();
+      final Size testSize = Size(230, 5);
+      final editor = MaterialApp(
+        home: FleatherEditor(
+            controller: controller,
+            focusNode: focusNode,
+            textSelectionControls:
+                MyTextSelectionControllers(testSize)),
+      ); 
+      await tester.pumpWidget(editor);
+      await tester.tap(find.byType(RawEditor).first);
+      await tester.pumpAndSettle();
+      expect(focusNode.hasFocus, isTrue);
+      tester.binding.scheduleWarmUpFrame();
+      final handleState =
+          tester.state(find.byType(MyTextSelectionHandle))
+              as MyTextSelectionHandleState;
+      expect(handleState.context.size, testSize);
+    });
+  });
+}

--- a/packages/fleather/test/widgets/editor_text_selection_controllers_test.dart
+++ b/packages/fleather/test/widgets/editor_text_selection_controllers_test.dart
@@ -55,7 +55,7 @@ void main() {
       ]);
       FleatherController controller = FleatherController(document: document);
       FocusNode focusNode = FocusNode();
-      final Size testSize = Size(230, 5);
+      const Size testSize = Size(230, 5);
       final editor = MaterialApp(
         home: FleatherEditor(
             controller: controller,

--- a/packages/fleather/test/widgets/editor_text_selection_controllers_test.dart
+++ b/packages/fleather/test/widgets/editor_text_selection_controllers_test.dart
@@ -10,8 +10,7 @@ import '../testing.dart';
 
 class MyTextSelectionHandle extends StatefulWidget {
   final Size size;
-  const MyTextSelectionHandle(
-      {super.key, required this.size});
+  const MyTextSelectionHandle({super.key, required this.size});
 
   @override
   State<StatefulWidget> createState() {
@@ -19,8 +18,7 @@ class MyTextSelectionHandle extends StatefulWidget {
   }
 }
 
-class MyTextSelectionHandleState
-    extends State<MyTextSelectionHandle> {
+class MyTextSelectionHandleState extends State<MyTextSelectionHandle> {
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -31,14 +29,13 @@ class MyTextSelectionHandleState
   }
 }
 
-class MyTextSelectionControllers
-    extends MaterialTextSelectionControls {
+class MyTextSelectionControllers extends MaterialTextSelectionControls {
   final Size size;
   MyTextSelectionControllers(this.size);
 
   @override
-  Widget buildHandle(BuildContext context,
-      TextSelectionHandleType type, double textHeight,
+  Widget buildHandle(
+      BuildContext context, TextSelectionHandleType type, double textHeight,
       [VoidCallback? onTap]) {
     final Widget handle = MyTextSelectionHandle(
       size: size,
@@ -46,43 +43,36 @@ class MyTextSelectionControllers
 
     return switch (type) {
       TextSelectionHandleType.left => Transform.rotate(
-          angle: math.pi / 2.0,
-          child: handle), // points up-right
-      TextSelectionHandleType.right =>
-        handle, // points up-left
-      TextSelectionHandleType.collapsed => Transform.rotate(
-          angle: math.pi / 4.0, child: handle), // points up
+          angle: math.pi / 2.0, child: handle), // points up-right
+      TextSelectionHandleType.right => handle, // points up-left
+      TextSelectionHandleType.collapsed =>
+        Transform.rotate(angle: math.pi / 4.0, child: handle), // points up
     };
   }
 }
 
 void main() {
-  group('CustomTextSelectionControllers', () { 
- 
-    testWidgets('set customTextSelectionControllers',
-        (tester) async { 
+  group('CustomTextSelectionControllers', () {
+    testWidgets('set customTextSelectionControllers', (tester) async {
       final document = ParchmentDocument.fromJson([
         {'insert': 'some text\n'}
       ]);
-      FleatherController controller =
-          FleatherController(document: document);
+      FleatherController controller = FleatherController(document: document);
       FocusNode focusNode = FocusNode();
       final Size testSize = Size(230, 5);
       final editor = MaterialApp(
         home: FleatherEditor(
             controller: controller,
             focusNode: focusNode,
-            textSelectionControls:
-                MyTextSelectionControllers(testSize)),
-      ); 
+            textSelectionControls: MyTextSelectionControllers(testSize)),
+      );
       await tester.pumpWidget(editor);
       await tester.tap(find.byType(RawEditor).first);
       await tester.pumpAndSettle();
       expect(focusNode.hasFocus, isTrue);
       tester.binding.scheduleWarmUpFrame();
-      final handleState =
-          tester.state(find.byType(MyTextSelectionHandle))
-              as MyTextSelectionHandleState;
+      final handleState = tester.state(find.byType(MyTextSelectionHandle))
+          as MyTextSelectionHandleState;
       expect(handleState.context.size, testSize);
     });
   });

--- a/packages/fleather/test/widgets/editor_text_selection_controllers_test.dart
+++ b/packages/fleather/test/widgets/editor_text_selection_controllers_test.dart
@@ -1,12 +1,8 @@
 import 'dart:math' as math;
 
 import 'package:fleather/fleather.dart';
-import 'package:fleather/src/widgets/editor_input_client_mixin.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import '../testing.dart';
 
 class MyTextSelectionHandle extends StatefulWidget {
   final Size size;


### PR DESCRIPTION
Hello, there is a bug in Flutter's `OverlayEntry` handling related to `TextSelectionTheme.of(context)`. Specifically, the issue causes  the color of `MaterialTextSelectionControls` to be lost when `buildHandle` is called. This can be seen in the Flutter source code at [https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/text_selection.dart#L77](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/text_selection.dart#L77).

A simple way to fix this issue would be to allow developers to use a custom `TextSelectionControls` implementation.