### PR TITLE
Avoid scrolling to cursor when tap on a checkbox

### DIFF
--- a/packages/fleather/lib/src/widgets/controller.dart
+++ b/packages/fleather/lib/src/widgets/controller.dart
@@ -21,10 +21,13 @@ List<String> _toggleableStyleKeys = [
 ];
 
 class FleatherController extends ChangeNotifier {
-  FleatherController({ParchmentDocument? document, AutoFormats? autoFormats})
+  FleatherController(
+      {ParchmentDocument? document,
+      AutoFormats? autoFormats,
+      this.skipScrollOnToggleLeading = false})
       : _document = document ?? ParchmentDocument(),
         _history = HistoryStack.doc(document),
-        _autoFormats = autoFormats ?? AutoFormats.fallback(),
+        _autoFormats = autoFormats ?? AutoFormats.fallback(), 
         _selection = const TextSelection.collapsed(offset: 0) {
     _throttledPush = _throttle(
       duration: throttleDuration,
@@ -42,6 +45,10 @@ class FleatherController extends ChangeNotifier {
 
   late _Throttled<Delta> _throttledPush;
   Timer? _throttleTimer;
+
+  // skipScroll if formatText but just for toggle leading checkbox
+  final bool skipScrollOnToggleLeading;
+  bool skipScroll = false;
 
   // The auto format handler
   final AutoFormats _autoFormats;
@@ -202,7 +209,8 @@ class FleatherController extends ChangeNotifier {
     return true;
   }
 
-  void formatText(int index, int length, ParchmentAttribute attribute) {
+  void formatText(int index, int length, ParchmentAttribute attribute,
+      {bool withoutScroll = false}) {
     final change = document.format(index, length, attribute);
     // _lastChangeSource = ChangeSource.local;
     const source = ChangeSource.local;
@@ -223,7 +231,9 @@ class FleatherController extends ChangeNotifier {
       _updateSelectionSilent(adjustedSelection, source: source);
     }
     _updateHistory();
+    skipScroll = withoutScroll;
     notifyListeners();
+    skipScroll = false;
   }
 
   /// Formats current selection with [attribute].

--- a/packages/fleather/lib/src/widgets/editable_text_block.dart
+++ b/packages/fleather/lib/src/widgets/editable_text_block.dart
@@ -256,7 +256,8 @@ class EditableTextBlock extends StatelessWidget {
   void _toggle(LineNode node, bool checked) {
     final attr =
         checked ? ParchmentAttribute.checked : ParchmentAttribute.checked.unset;
-    controller.formatText(node.documentOffset, 0, attr);
+    controller.formatText(node.documentOffset, 0, attr,
+        withoutScroll: controller.skipScrollOnToggleLeading);
   }
 }
 

--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -1594,6 +1594,10 @@ class RawEditorState extends EditorState
       return;
     }
 
+    if (widget.controller.skipScroll) {
+      return;
+    }
+
     _showCaretOnScreenScheduled = true;
     SchedulerBinding.instance.addPostFrameCallback((Duration _) {
       _showCaretOnScreenScheduled = false;


### PR DESCRIPTION
Hi, I don't know if this is a bug or a feature. But every time I open FleatherEditor, scroll to the bottom, and just want to change the checkbox, it scrolls to the top. I feel bad, so is it possible to make it optional?

Please give me some advice? I'll add a test if I can.

https://github.com/user-attachments/assets/93a78614-e0b8-4d9e-bddb-004476d815dd

