### PR TITLE
Always keep natural order of selection boundaries

### DIFF
--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -1264,9 +1264,9 @@ class RawEditorState extends EditorState
     final TextSelection selection = textEditingValue.selection;
     widget.clipboardManager.setData(FleatherClipboardData(
       plainText: selection.textInside(textEditingValue.text),
-      delta: controller.document
-          .toDelta()
-          .slice(selection.baseOffset, selection.extentOffset),
+      delta: controller.document.toDelta().slice(
+          math.min(selection.baseOffset, selection.extentOffset),
+          math.max(selection.baseOffset, selection.extentOffset)),
     ));
   }
 

--- a/packages/fleather/test/widgets/editor_test.dart
+++ b/packages/fleather/test/widgets/editor_test.dart
@@ -351,6 +351,35 @@ void main() {
       expect(sentData?.delta, Delta()..insert('t T'));
     });
 
+    testWidgets(
+        'Copy sends correct data to clipboard manager when selection extents are inverted',
+        (tester) async {
+      prepareClipboard();
+      FleatherClipboardData? sentData;
+      final editor = EditorSandBox(
+        tester: tester,
+        document: ParchmentDocument.fromJson([
+          {'insert': 'Test Text\n'}
+        ]),
+        autofocus: true,
+        clipboardManager: FleatherCustomClipboardManager(
+          getData: () => throw UnimplementedError(),
+          setData: (data) async => sentData = data,
+        ),
+      );
+      await editor.pump();
+      final RawEditorState state =
+          tester.state<RawEditorState>(find.byType(RawEditor));
+      await editor.updateSelection(base: 6, extent: 3);
+      state.showToolbar(createIfNull: true);
+      await tester.pump();
+      final finder = find.text('Copy');
+      await tester.tap(finder);
+      await tester.pumpAndSettle(throttleDuration);
+      expect(sentData?.plainText, 't T');
+      expect(sentData?.delta, Delta()..insert('t T'));
+    });
+
     testWidgets('Cut intent sends data to clipboard manager', (tester) async {
       prepareClipboard();
       FleatherClipboardData? sentData;


### PR DESCRIPTION
when setting clipboard data, selection extent can be inverted (notably on macOS) if selection was made from end to start
This fixes the issue by calling Delta::slice with natural order of selection extents