### PR TITLE
fix: editor crashes when multi level list uses different list types

### DIFF
--- a/packages/fleather/lib/src/widgets/editable_text_block.dart
+++ b/packages/fleather/lib/src/widgets/editable_text_block.dart
@@ -156,7 +156,8 @@ class EditableTextBlock extends StatelessWidget {
       if (lastLevel != null) {
         if (lastLevel == currentLevel) {
           currentIndex = levelsIndexes[lastLevel]! + 1;
-        } else if (lastLevel > currentLevel) {
+        } else if (levelsIndexes.containsKey(currentLevel) &&
+            lastLevel > currentLevel) {
           currentIndex = levelsIndexes[currentLevel]! + 1;
         }
       }

--- a/packages/fleather/test/widgets/editable_text_test.dart
+++ b/packages/fleather/test/widgets/editable_text_test.dart
@@ -114,6 +114,26 @@ void main() {
         await editor.pump();
         expect(find.text('1.', findRichText: true), findsOneWidget);
       });
+
+      testWidgets('multi-level numbered list', (tester) async {
+        final delta = Delta()
+          ..insert('an item')
+          ..insert('\n', {'block': 'ul'})
+          ..insert('1')
+          ..insert('\n', {'indent': 1, 'block': 'ol'})
+          ..insert('1.1')
+          ..insert('\n', {'block': 'ol'})
+          ..insert('2')
+          ..insert('\n');
+        final editor = EditorSandBox(
+            tester: tester, document: ParchmentDocument.fromDelta(delta));
+        await editor.pump();
+        expect(find.text('1.', findRichText: true), findsNWidgets(2));
+      });
+
+      /*
+      [{"insert":"Example "},{"insert":"\n","attributes":{"heading":1}},{"insert":"Test"},{"insert":"\n","attributes":{"block":"ul"}},{"insert":"Other"},{"insert":"\n","attributes":{"indent":1}},{"insert":"Another level"},{"insert":"\n","attributes":{"indent":2,"block":"ol"}},{"insert":"Some stuff"},{"insert":"\n","attributes":{"indent":1,"block":"ol"}}]
+      */
     });
 
     testWidgets('headings', (tester) async {

--- a/packages/fleather/test/widgets/editable_text_test.dart
+++ b/packages/fleather/test/widgets/editable_text_test.dart
@@ -130,10 +130,6 @@ void main() {
         await editor.pump();
         expect(find.text('1.', findRichText: true), findsNWidgets(2));
       });
-
-      /*
-      [{"insert":"Example "},{"insert":"\n","attributes":{"heading":1}},{"insert":"Test"},{"insert":"\n","attributes":{"block":"ul"}},{"insert":"Other"},{"insert":"\n","attributes":{"indent":1}},{"insert":"Another level"},{"insert":"\n","attributes":{"indent":2,"block":"ol"}},{"insert":"Some stuff"},{"insert":"\n","attributes":{"indent":1,"block":"ol"}}]
-      */
     });
 
     testWidgets('headings', (tester) async {


### PR DESCRIPTION
### Why 
When the list type of a multi level list is switched the editor crashes. For example, given the following list with 2 levels:
1. Ordered 1  [level 1]
   - Unordered 1 [level 2]
2. Ordered 2 [level 1]

If "1. " is changed to an unordered list, the editor crashes with a null pointer exception because it expects each list level to use the same type.

### What Changed
When looking for the next index number to apply for a numbered list check if the current level has an entry.

### Testing
Added a new multi-level numbered list test