### PR TITLE
Image attributes

### DIFF
--- a/packages/parchment/lib/src/codecs/html.dart
+++ b/packages/parchment/lib/src/codecs/html.dart
@@ -491,10 +491,22 @@ class _ParchmentHtmlEncoder extends Converter<ParchmentDocument, String> {
           return;
         }
         if (embeddable.type == 'image') {
-          // Force the image to fit within any max. width that might be set. If
-          // no width or max-width is set on an outer block, then this does nothing.
-          buffer.write(
-              '<img src="${embeddable.data['source']}" style="max-width: 100%; object-fit: contain;">');
+          final attributes = StringBuffer();
+          if (embeddable.data['width'] != null) {
+            attributes.write(' width="${embeddable.data['width']}"');
+          }
+          if (embeddable.data['height'] != null) {
+            attributes.write(' height="${embeddable.data['height']}"');
+          }
+          if (embeddable.data['alt'] != null) {
+            attributes.write(' alt="${embeddable.data['alt']}"');
+          }
+          if (embeddable.data['style'] != null) {
+            attributes.write(' style="${embeddable.data['style']}"');
+          } else {
+            attributes.write(' style="max-width: 100%; object-fit: contain;"');
+          }
+          buffer.write('<img src="${embeddable.data['source']}"$attributes>');
           return;
         }
       }
@@ -898,8 +910,19 @@ class _ParchmentHtmlDecoder extends Converter<String, ParchmentDocument> {
         return delta;
       }
       if (node.localName == 'img') {
-        final src = node.attributes['src'] ?? '';
-        delta.insert(BlockEmbed.image(src).toJson());
+        final String src = node.attributes['src'] ?? '';
+        final int? width = int.tryParse(node.attributes['width'] ?? '');
+        final int? height = int.tryParse(node.attributes['height'] ?? '');
+        final String? alt = node.attributes['alt'];
+        final String? style = node.attributes['style'];
+
+        final Map<String, dynamic> data = {'source': src};
+        if (width != null) data['width'] = width;
+        if (height != null) data['height'] = height;
+        if (alt != null) data['alt'] = alt;
+        if (style != null) data['style'] = style;
+
+        delta.insert(BlockEmbed.image(data).toJson());
         // <img> can be enclosed in a <p> element, but
         // we only want to support <p> with only one node (<img>)
         if (node.parent is html.Element &&

--- a/packages/parchment/lib/src/document/embeds.dart
+++ b/packages/parchment/lib/src/document/embeds.dart
@@ -98,6 +98,6 @@ class BlockEmbed extends EmbeddableObject {
   }) : super(inline: false);
 
   static final BlockEmbed horizontalRule = BlockEmbed('hr');
-  static BlockEmbed image(String source) =>
-      BlockEmbed('image', data: {'source': source});
+  static BlockEmbed image(Map<String, dynamic> data) =>
+      BlockEmbed('image', data: data);
 }

--- a/packages/parchment/test/codecs/html_test.dart
+++ b/packages/parchment/test/codecs/html_test.dart
@@ -1098,7 +1098,8 @@ void main() {
         final doc = ParchmentDocument.fromJson([
           {'insert': '\n'}
         ]);
-        doc.insert(0, BlockEmbed.image('http://fake.link/image.png'));
+        doc.insert(
+            0, BlockEmbed.image({'source': 'http://fake.link/image.png'}));
 
         expect(codec.encode(doc), html);
       });
@@ -1718,18 +1719,28 @@ void main() {
           {'insert': '\n'}
         ]);
         doc.insert(0, 'a');
-        doc.insert(0, BlockEmbed.image('http://another.fake.link/image.png'));
-        doc.insert(0, BlockEmbed.image('http://fake.link/image.png'));
+        doc.insert(0,
+            BlockEmbed.image({'source': 'http://another.fake.link/image.png'}));
+        doc.insert(
+            0, BlockEmbed.image({'source': 'http://fake.link/image.png'}));
         doc.insert(0, BlockEmbed.horizontalRule);
         expect(codec.decode(html).toDelta(), doc.toDelta());
       });
 
       test('Image', () {
-        final html = '<img src="http://fake.link/image.png">';
+        final html =
+            '<img src="http://fake.link/image.png" width="100" height="100" alt="image">';
         final doc = ParchmentDocument.fromJson([
           {'insert': '\n'}
         ]);
-        doc.insert(0, BlockEmbed.image('http://fake.link/image.png'));
+        doc.insert(
+            0,
+            BlockEmbed.image({
+              'source': 'http://fake.link/image.png',
+              'width': 100,
+              'height': 100,
+              'alt': 'image'
+            }));
 
         expect(codec.decode(html).toDelta(), doc.toDelta());
       });


### PR DESCRIPTION
Image attributes for HTML tag compatibility:

`<img src="http://fake.link/image.png" width="100" height="100" alt="image">`

```
BlockEmbed.image({
  'source': 'http://fake.link/image.png',
  'width': 100,
  'height': 100,
  'alt': 'image'
});
```
