### PR TITLE
Fix floating cursor position issue by fixing getLocalRectForCaret

### DIFF
--- a/packages/fleather/lib/src/rendering/editor.dart
+++ b/packages/fleather/lib/src/rendering/editor.dart
@@ -187,17 +187,7 @@ class RenderEditor extends RenderEditableContainerBox
     markNeedsSemanticsUpdate();
   }
 
-  Offset get paintOffset {
-    final double dx;
-    if (padding is EdgeInsets) {
-      dx = (padding as EdgeInsets).left;
-    } else if (padding is EdgeInsetsDirectional) {
-      dx = (padding as EdgeInsetsDirectional).start;
-    } else {
-      dx = 0.0;
-    }
-    return Offset(-dx, -offset.pixels);
-  }
+  Offset get paintOffset => Offset(0.0, -offset.pixels);
 
   ViewportOffset get offset => _offset;
   ViewportOffset _offset;
@@ -762,8 +752,8 @@ class RenderEditor extends RenderEditableContainerBox
     final childLocalRect = targetChild.getLocalRectForCaret(localPosition);
 
     final boxParentData = targetChild.parentData as BoxParentData;
-    return childLocalRect
-        .shift(Offset(0, boxParentData.offset.dy + paintOffset.dy));
+    return childLocalRect.shift(Offset(
+        resolvedPadding!.left, boxParentData.offset.dy + paintOffset.dy));
   }
 
   // Start floating cursor


### PR DESCRIPTION
This is an attempt to fix #483 while preventing issue caused by #484. Since we are already adding padding offset to children, we shouldn't change the paint offset based on padding.

Before (Example app):
![image](https://github.com/user-attachments/assets/2dd95349-54e4-46bb-b9fc-ebd4ebf8eeb4)
After:
![image](https://github.com/user-attachments/assets/113f33c9-d695-46c6-8ed8-daf9fa403050)
