### PR TITLE
Not display iOS native context menu on read only mode.

### DIFF
--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -48,7 +48,8 @@ typedef FleatherContextMenuBuilder = Widget Function(
 Widget defaultContextMenuBuilder(
     BuildContext context, EditorState editorState) {
   if (defaultTargetPlatform == TargetPlatform.iOS &&
-      SystemContextMenu.isSupported(context)) {
+      SystemContextMenu.isSupported(context) &&
+      !editorState.widget.readOnly) {
     return SystemContextMenu.editor(editorState: editorState);
   }
   return AdaptiveTextSelectionToolbar.buttonItems(

--- a/packages/fleather/test/widgets/editor_test.dart
+++ b/packages/fleather/test/widgets/editor_test.dart
@@ -378,6 +378,33 @@ void main() {
     }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
     testWidgets(
+        'Does not use system context menu on iOS when editor is read-only',
+        (tester) async {
+      // if Clipboard not initialize (status 'unknown'), an shrunken toolbar appears
+      prepareClipboard();
+
+      final editor = EditorSandBox(
+        tester: tester,
+        document: ParchmentDocument(),
+        autofocus: true,
+        appBuilder: (context, child) => MediaQuery(
+          data: MediaQuery.of(context)
+              .copyWith(supportsShowingSystemContextMenu: true),
+          child: child!,
+        ),
+      );
+      await editor.pump();
+      await editor.disable();
+
+      expect(find.text('Paste'), findsNothing);
+      await tester.longPress(find.byType(FleatherEditor));
+      await tester.pump();
+
+      expect(find.byType(SystemContextMenu), findsNothing);
+      expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+
+    testWidgets(
         'Uses adaptive context menu if platform is not iOS or is iOS but system context menu is not supported',
         (tester) async {
       // if Clipboard not initialize (status 'unknown'), an shrunken toolbar appears


### PR DESCRIPTION
iOS native context menu needs active text input connection. If the editor is on read-only mode, there is no active text input connection and Flutter throws exception.

Fix: not show iOS native context menu if the editor is on read-only mode.

Solves: https://github.com/fleather-editor/fleather/issues/513