### PR TITLE
fix: horizontal rule theme data merge with

### DIFF
--- a/packages/fleather/lib/src/widgets/theme.dart
+++ b/packages/fleather/lib/src/widgets/theme.dart
@@ -335,6 +335,7 @@ class FleatherThemeData {
       lists: other.lists,
       quote: other.quote,
       code: other.code,
+      horizontalRuleThemeData: other.horizontalRule,
     );
   }
 }


### PR DESCRIPTION
added the missing property