### PR TITLE
feat: Add image support to Parchment Markdown codec

### DIFF
--- a/packages/parchment/example/image_demo.dart
+++ b/packages/parchment/example/image_demo.dart
@@ -1,0 +1,40 @@
+import 'package:parchment/codecs.dart';
+import 'package:parchment/parchment.dart';
+
+void main() {
+  print('=== Image Support in Parchment Markdown Codec ===\n');
+
+  // Test 1: Markdown to Parchment (Decoding)
+  print('1. Decoding Markdown with image to Parchment:');
+  final markdown = '![Alt text](https://example.com/image.jpg)';
+  print('Input: $markdown');
+
+  final document = parchmentMarkdown.decode(markdown);
+  final delta = document.toDelta();
+
+  final embed = delta.elementAt(0).data as BlockEmbed;
+  print('Output: Image embed with source: ${embed.data['source']}');
+  print('');
+
+  // Test 2: Parchment to Markdown (Encoding)
+  print('2. Encoding Parchment with image to Markdown:');
+  final imageEmbed = BlockEmbed.image('https://example.com/my-image.png');
+  final deltaWithImage = Delta()
+    ..insert(imageEmbed)
+    ..insert('\n');
+  final documentWithImage = ParchmentDocument.fromDelta(deltaWithImage);
+
+  final encodedMarkdown = parchmentMarkdown.encode(documentWithImage);
+  print('Output: $encodedMarkdown');
+
+  // Test 3: Round-trip conversion
+  print('3. Round-trip conversion:');
+  final originalMarkdown = '![Test image](https://example.com/test.jpg)';
+  final roundTripDocument = parchmentMarkdown.decode(originalMarkdown);
+  final backToMarkdown = parchmentMarkdown.encode(roundTripDocument);
+
+  print('Original: $originalMarkdown');
+  print('Round-trip: ${backToMarkdown.trim()}');
+  print(
+      'Success: ${backToMarkdown.contains('![](https://example.com/test.jpg)')}');
+}


### PR DESCRIPTION
# 📝 Description

Implements bidirectional image support for `ParchmentMarkdownCodec`. Previously, images were silently dropped during Markdown encoding. Now images are preserved in both directions: Markdown ↔ Parchment.

## ✨ What's New

* **Decode**: `!alt` → `BlockEmbed.image(url)`
* **Encode**: `BlockEmbed.image(url)` → `![](url)`
* **Round-trip**: Images maintain data integrity through conversions

## 🛠️ Implementation

### Decoder
* Added `_imageRegExp` pattern and `_handleImage()` method
* Processes images before other block elements

### Encoder
* Enhanced `handleLine()` to detect image embeds specifically
* Converts to `![](url)` format while skipping other embeds

## 🧪 Tests Added

* Basic image parsing (with/without alt text)
* Multiple images
* Images with surrounding text
* Encoding and round-trip conversion

## 📋 Example

```dart
// Decode
final doc = parchmentMarkdown.decode('![](https://example.com/img.jpg)');

// Encode
final markdown = parchmentMarkdown.encode(docWithImage);
// Output: "![](https://example.com/img.jpg)\n\n"
```
✅ Backward Compatible

- All existing functionality unchanged
- Other embeds still skipped during encoding
- All existing tests pass