### PR TITLE
Release v1.24.0+1

### DIFF
--- a/packages/fleather/CHANGELOG.md
+++ b/packages/fleather/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.24.0
+## 1.24.0+1
 
 * Use Flutter context menu when read-only on iOS
 * Add translations for Hungarian

--- a/packages/fleather/README.md
+++ b/packages/fleather/README.md
@@ -25,7 +25,7 @@ Add Fleather to your dependencies.
 dependencies:
   flutter:
     sdk: flutter
-  fleather: ^1.24.0
+  fleather: ^1.24.0+1
 ```
 
 ## Usage

--- a/packages/fleather/pubspec.yaml
+++ b/packages/fleather/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fleather
 description: Clean, minimalistic and collaboration-ready rich text editor for Flutter.
-version: 1.24.0
+version: 1.24.0+1
 homepage: https://fleather-editor.github.io
 repository: https://github.com/fleather-editor/fleather
 issue_tracker: https://github.com/fleather-editor/fleather/issues
@@ -26,7 +26,7 @@ dependencies:
     sdk: flutter
   collection: ^1.19.1
   parchment_delta: ^1.0.0
-  parchment: ^1.22.0
+  parchment: ^1.24.0
   intl: ">=0.19.0 <0.21.0"
 
 dependency_overrides:


### PR DESCRIPTION
Fixes the mistake in previous release (v1.24.0) where the old version of parchment was used in Fleather.