### PR TITLE
Allow the editor in read-only to tighten to the actual necessary width

### DIFF
--- a/packages/fleather/example/macos/Podfile.lock
+++ b/packages/fleather/example/macos/Podfile.lock
@@ -19,9 +19,9 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
-  file_selector_macos: 6280b52b459ae6c590af5d78fc35c7267a3c4b31
+  file_selector_macos: cc3858c981fe6889f364731200d6232dac1d812d
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  url_launcher_macos: 0fba8ddabfc33ce0a9afe7c5fef5aab3d8d2d673
+  url_launcher_macos: c82c93949963e55b228a30115bd219499a6fe404
 
 PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7
 

--- a/packages/fleather/lib/src/widgets/editable_text_block.dart
+++ b/packages/fleather/lib/src/widgets/editable_text_block.dart
@@ -19,6 +19,7 @@ class EditableTextBlock extends StatelessWidget {
   final bool readOnly;
   final VerticalSpacing spacing;
   final CursorController cursorController;
+  final TextWidthBasis textWidthBasis;
   final TextSelection selection;
   final Color selectionColor;
   final bool enableInteractiveSelection;
@@ -35,6 +36,7 @@ class EditableTextBlock extends StatelessWidget {
     required this.readOnly,
     required this.spacing,
     required this.cursorController,
+    required this.textWidthBasis,
     required this.selection,
     required this.selectionColor,
     required this.enableInteractiveSelection,
@@ -83,6 +85,7 @@ class EditableTextBlock extends StatelessWidget {
             embedBuilder: embedBuilder,
             linkActionPicker: linkActionPicker,
             onLaunchUrl: onLaunchUrl,
+            textWidthBasis: textWidthBasis,
           ),
           cursorController: cursorController,
           selection: selection,

--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -182,10 +182,11 @@ class FleatherEditor extends StatefulWidget {
   /// the text field from the clipboard.
   final bool enableInteractiveSelection;
 
-  /// Defines how to measure the width of the rendered when [readOnly] is `true`
-  /// text. Otherwise the value is ignored and forced to [TextWidthBasis.parent]
+  /// Defines how to measure the width of the rendered text when [readOnly] is
+  /// `true`. Otherwise the value is ignored and forced to
+  /// [TextWidthBasis.parent]
   ///
-  /// Default to [TextWidthBasis.parent].
+  /// Defaults to [TextWidthBasis.parent].
   final TextWidthBasis textWidthBasis;
 
   /// The minimum height to be occupied by this editor.
@@ -982,6 +983,9 @@ class RawEditorState extends EditorState
     return result!;
   }
 
+  TextWidthBasis get _textWidthBasis =>
+      widget.readOnly ? widget.textWidthBasis : TextWidthBasis.parent;
+
   /// The renderer for this widget's editor descendant.
   ///
   /// This property is typically used to notify the renderer of input gestures.
@@ -1718,10 +1722,6 @@ class RawEditorState extends EditorState
 
     final Widget child;
 
-    // In edition mode, force to TextWidthBasis.parent
-    final textWidthBasis =
-        widget.readOnly ? widget.textWidthBasis : TextWidthBasis.parent;
-
     if (widget.scrollable) {
       child = Scrollable(
         key: _scrollableKey,
@@ -1748,7 +1748,7 @@ class RawEditorState extends EditorState
             padding: widget.padding,
             maxContentWidth: widget.maxContentWidth,
             cursorController: _cursorController,
-            textWidthBasis: textWidthBasis,
+            textWidthBasis: _textWidthBasis,
             children: _buildChildren(context),
           ),
         ),
@@ -1770,7 +1770,7 @@ class RawEditorState extends EditorState
             onSelectionChanged: _handleSelectionChanged,
             padding: widget.padding,
             maxContentWidth: widget.maxContentWidth,
-            textWidthBasis: textWidthBasis,
+            textWidthBasis: _textWidthBasis,
             children: _buildChildren(context),
           ),
         ),
@@ -1826,6 +1826,7 @@ class RawEditorState extends EditorState
               embedBuilder: widget.embedBuilder,
               linkActionPicker: _linkActionPicker,
               onLaunchUrl: widget.onLaunchUrl,
+              textWidthBasis: widget.textWidthBasis,
             ),
             hasFocus: _hasFocus,
             devicePixelRatio: MediaQuery.of(context).devicePixelRatio,
@@ -1843,6 +1844,7 @@ class RawEditorState extends EditorState
             cursorController: _cursorController,
             selection: widget.controller.selection,
             selectionColor: widget.selectionColor,
+            textWidthBasis: _textWidthBasis,
             enableInteractiveSelection: widget.enableInteractiveSelection,
             hasFocus: _hasFocus,
             contentPadding: (block == ParchmentAttribute.block.code)

--- a/packages/fleather/lib/src/widgets/editor.dart
+++ b/packages/fleather/lib/src/widgets/editor.dart
@@ -182,6 +182,12 @@ class FleatherEditor extends StatefulWidget {
   /// the text field from the clipboard.
   final bool enableInteractiveSelection;
 
+  /// Defines how to measure the width of the rendered when [readOnly] is `true`
+  /// text. Otherwise the value is ignored and forced to [TextWidthBasis.parent]
+  ///
+  /// Default to [TextWidthBasis.parent].
+  final TextWidthBasis textWidthBasis;
+
   /// The minimum height to be occupied by this editor.
   ///
   /// This only has effect if [scrollable] is set to `true` and [expands] is
@@ -309,6 +315,7 @@ class FleatherEditor extends StatefulWidget {
       this.autocorrect = true,
       this.enableSuggestions = true,
       this.enableInteractiveSelection = true,
+      this.textWidthBasis = TextWidthBasis.parent,
       this.minHeight,
       this.maxHeight,
       this.maxContentWidth,
@@ -486,6 +493,7 @@ class _FleatherEditorState extends State<FleatherEditor>
       readOnly: widget.readOnly,
       enableSuggestions: widget.enableSuggestions,
       enableInteractiveSelection: widget.enableInteractiveSelection,
+      textWidthBasis: widget.textWidthBasis,
       minHeight: widget.minHeight,
       maxHeight: widget.maxHeight,
       maxContentWidth: widget.maxContentWidth,
@@ -589,6 +597,7 @@ class RawEditor extends StatefulWidget {
     this.autocorrect = true,
     this.enableSuggestions = true,
     this.enableInteractiveSelection = true,
+    this.textWidthBasis = TextWidthBasis.parent,
     this.minHeight,
     this.maxHeight,
     this.maxContentWidth,
@@ -715,6 +724,9 @@ class RawEditor extends StatefulWidget {
   ///
   ///  * [TextCapitalization], for a description of each capitalization behavior.
   final TextCapitalization textCapitalization;
+
+  /// Defines how to measure the width of the rendered text.
+  final TextWidthBasis textWidthBasis;
 
   /// The maximum height this editor can have.
   ///
@@ -1706,6 +1718,10 @@ class RawEditorState extends EditorState
 
     final Widget child;
 
+    // In edition mode, force to TextWidthBasis.parent
+    final textWidthBasis =
+        widget.readOnly ? widget.textWidthBasis : TextWidthBasis.parent;
+
     if (widget.scrollable) {
       child = Scrollable(
         key: _scrollableKey,
@@ -1732,6 +1748,7 @@ class RawEditorState extends EditorState
             padding: widget.padding,
             maxContentWidth: widget.maxContentWidth,
             cursorController: _cursorController,
+            textWidthBasis: textWidthBasis,
             children: _buildChildren(context),
           ),
         ),
@@ -1753,6 +1770,7 @@ class RawEditorState extends EditorState
             onSelectionChanged: _handleSelectionChanged,
             padding: widget.padding,
             maxContentWidth: widget.maxContentWidth,
+            textWidthBasis: textWidthBasis,
             children: _buildChildren(context),
           ),
         ),
@@ -2182,6 +2200,7 @@ class _Editor extends MultiChildRenderObjectWidget {
     required this.endHandleLayerLink,
     required this.onSelectionChanged,
     required this.cursorController,
+    required this.textWidthBasis,
     this.padding = EdgeInsets.zero,
     this.maxContentWidth,
   });
@@ -2196,6 +2215,7 @@ class _Editor extends MultiChildRenderObjectWidget {
   final TextSelectionChangedHandler onSelectionChanged;
   final EdgeInsetsGeometry padding;
   final double? maxContentWidth;
+  final TextWidthBasis textWidthBasis;
   final CursorController cursorController;
 
   @override
@@ -2212,6 +2232,7 @@ class _Editor extends MultiChildRenderObjectWidget {
       cursorController: cursorController,
       padding: padding,
       maxContentWidth: maxContentWidth,
+      textWidthBasis: textWidthBasis,
     );
   }
 
@@ -2229,6 +2250,7 @@ class _Editor extends MultiChildRenderObjectWidget {
     renderObject.onSelectionChanged = onSelectionChanged;
     renderObject.padding = padding;
     renderObject.maxContentWidth = maxContentWidth;
+    renderObject.textWidthBasis = textWidthBasis;
   }
 }
 

--- a/packages/fleather/lib/src/widgets/field.dart
+++ b/packages/fleather/lib/src/widgets/field.dart
@@ -91,6 +91,12 @@ class FleatherField extends StatefulWidget {
   /// the text field from the clipboard.
   final bool enableInteractiveSelection;
 
+  /// Defines how to measure the width of the rendered when [readOnly] is `true`
+  /// text. Otherwise the value is ignored and forced to [TextWidthBasis.parent]
+  ///
+  /// Default to [TextWidthBasis.parent].
+  final TextWidthBasis textWidthBasis;
+
   /// The minimum height to be occupied by this editor.
   ///
   /// This only has effect if [scrollable] is set to `true` and [expands] is
@@ -192,6 +198,7 @@ class FleatherField extends StatefulWidget {
     this.autocorrect = true,
     this.enableSuggestions = true,
     this.enableInteractiveSelection = true,
+    this.textWidthBasis = TextWidthBasis.parent,
     this.minHeight,
     this.maxHeight,
     this.expands = false,
@@ -264,6 +271,7 @@ class _FleatherFieldState extends State<FleatherField> {
       autocorrect: widget.autocorrect,
       enableSuggestions: widget.enableSuggestions,
       enableInteractiveSelection: widget.enableInteractiveSelection,
+      textWidthBasis: widget.textWidthBasis,
       minHeight: widget.minHeight,
       maxHeight: widget.maxHeight,
       expands: widget.expands,

--- a/packages/fleather/lib/src/widgets/field.dart
+++ b/packages/fleather/lib/src/widgets/field.dart
@@ -91,10 +91,11 @@ class FleatherField extends StatefulWidget {
   /// the text field from the clipboard.
   final bool enableInteractiveSelection;
 
-  /// Defines how to measure the width of the rendered when [readOnly] is `true`
-  /// text. Otherwise the value is ignored and forced to [TextWidthBasis.parent]
+  /// Defines how to measure the width of the rendered text when [readOnly] is
+  /// `true`. Otherwise the value is ignored and forced to
+  /// [TextWidthBasis.parent]
   ///
-  /// Default to [TextWidthBasis.parent].
+  /// Defaults to [TextWidthBasis.parent].
   final TextWidthBasis textWidthBasis;
 
   /// The minimum height to be occupied by this editor.

--- a/packages/fleather/lib/src/widgets/text_line.dart
+++ b/packages/fleather/lib/src/widgets/text_line.dart
@@ -123,6 +123,7 @@ class _TextLineState extends State<TextLine> {
       final embed = widget.node.children.single as EmbedNode;
       return EmbedProxy(child: widget.embedBuilder(context, embed));
     }
+    final editorState = context.findAncestorStateOfType<RawEditorState>()!;
     final text = buildText(context, widget.node);
     final textAlign = getTextAlign(widget.node);
     final strutStyle = StrutStyle.fromTextStyle(text.style!);
@@ -136,6 +137,7 @@ class _TextLineState extends State<TextLine> {
         text: text,
         textAlign: textAlign,
         strutStyle: strutStyle,
+        textWidthBasis: editorState.widget.textWidthBasis,
         textScaler: MediaQuery.textScalerOf(context),
       ),
     );

--- a/packages/fleather/lib/src/widgets/text_line.dart
+++ b/packages/fleather/lib/src/widgets/text_line.dart
@@ -26,6 +26,7 @@ class TextLine extends StatefulWidget {
   final FleatherEmbedBuilder embedBuilder;
   final ValueChanged<String?>? onLaunchUrl;
   final LinkActionPicker linkActionPicker;
+  final TextWidthBasis textWidthBasis;
 
   const TextLine({
     super.key,
@@ -35,6 +36,7 @@ class TextLine extends StatefulWidget {
     required this.embedBuilder,
     required this.onLaunchUrl,
     required this.linkActionPicker,
+    required this.textWidthBasis,
   });
 
   @override
@@ -123,7 +125,6 @@ class _TextLineState extends State<TextLine> {
       final embed = widget.node.children.single as EmbedNode;
       return EmbedProxy(child: widget.embedBuilder(context, embed));
     }
-    final editorState = context.findAncestorStateOfType<RawEditorState>()!;
     final text = buildText(context, widget.node);
     final textAlign = getTextAlign(widget.node);
     final strutStyle = StrutStyle.fromTextStyle(text.style!);
@@ -137,7 +138,7 @@ class _TextLineState extends State<TextLine> {
         text: text,
         textAlign: textAlign,
         strutStyle: strutStyle,
-        textWidthBasis: editorState.widget.textWidthBasis,
+        textWidthBasis: widget.textWidthBasis,
         textScaler: MediaQuery.textScalerOf(context),
       ),
     );

--- a/packages/fleather/test/testing.dart
+++ b/packages/fleather/test/testing.dart
@@ -14,8 +14,13 @@ class EditorSandBox {
     ParchmentDocument? document,
     FleatherThemeData? fleatherTheme,
     bool autofocus = false,
+    bool readOnly = false,
+    bool showCursor = true,
+    bool scrollable = true,
+    bool useField = true,
     bool enableSelectionInteraction = true,
     FakeSpellCheckService? spellCheckService,
+    TextWidthBasis textWidthBasis = TextWidthBasis.parent,
     ClipboardManager clipboardManager = const PlainTextClipboardManager(),
     FleatherEmbedBuilder embedBuilder = defaultFleatherEmbedBuilder,
     TransitionBuilder? appBuilder,
@@ -25,10 +30,15 @@ class EditorSandBox {
     var controller = FleatherController(document: document);
 
     Widget widget = _FleatherSandbox(
+      useField: useField,
       controller: controller,
       focusNode: focusNode,
       autofocus: autofocus,
+      scrollable: scrollable,
+      readOnly: readOnly,
+      showCursor: showCursor,
       enableSelectionInteraction: enableSelectionInteraction,
+      textWidthBasis: textWidthBasis,
       spellCheckService: spellCheckService,
       embedBuilder: embedBuilder,
       clipboardManager: clipboardManager,
@@ -140,44 +150,79 @@ class _FleatherSandbox extends StatefulWidget {
   const _FleatherSandbox({
     required this.controller,
     required this.focusNode,
+    this.useField = true,
     this.autofocus = false,
+    this.readOnly = false,
+    this.scrollable = true,
+    this.showCursor = true,
     this.enableSelectionInteraction = true,
     this.spellCheckService,
+    required this.textWidthBasis,
     this.embedBuilder = defaultFleatherEmbedBuilder,
     this.clipboardManager = const PlainTextClipboardManager(),
   });
 
+  final bool useField;
   final FleatherController controller;
   final FocusNode focusNode;
   final bool autofocus;
+  final bool readOnly;
+  final bool showCursor;
+  final bool scrollable;
   final bool enableSelectionInteraction;
   final FakeSpellCheckService? spellCheckService;
   final FleatherEmbedBuilder embedBuilder;
   final ClipboardManager clipboardManager;
+  final TextWidthBasis textWidthBasis;
 
   @override
   _FleatherSandboxState createState() => _FleatherSandboxState();
 }
 
 class _FleatherSandboxState extends State<_FleatherSandbox> {
-  bool _enabled = true;
+  late bool _enabled = !widget.readOnly;
 
   @override
   Widget build(BuildContext context) {
     return Material(
-      child: FleatherField(
-        clipboardManager: widget.clipboardManager,
-        embedBuilder: widget.embedBuilder,
-        controller: widget.controller,
-        focusNode: widget.focusNode,
-        readOnly: !_enabled,
-        enableInteractiveSelection: widget.enableSelectionInteraction,
-        autofocus: widget.autofocus,
-        spellCheckConfiguration: widget.spellCheckService != null
-            ? SpellCheckConfiguration(
-                spellCheckService: widget.spellCheckService,
+      // Add alignment to loosen the constraints set by tester
+      child: Align(
+        alignment: Alignment.topLeft,
+        child: widget.useField
+            ? FleatherField(
+                clipboardManager: widget.clipboardManager,
+                embedBuilder: widget.embedBuilder,
+                controller: widget.controller,
+                focusNode: widget.focusNode,
+                readOnly: !_enabled,
+                showCursor: widget.showCursor,
+                scrollable: widget.scrollable,
+                textWidthBasis: widget.textWidthBasis,
+                enableInteractiveSelection: widget.enableSelectionInteraction,
+                autofocus: widget.autofocus,
+                spellCheckConfiguration: widget.spellCheckService != null
+                    ? SpellCheckConfiguration(
+                        spellCheckService: widget.spellCheckService,
+                      )
+                    : null,
               )
-            : null,
+            : FleatherEditor(
+                clipboardManager: widget.clipboardManager,
+                embedBuilder: widget.embedBuilder,
+                controller: widget.controller,
+                focusNode: widget.focusNode,
+                readOnly: !_enabled,
+                showCursor: widget.showCursor,
+                scrollable: widget.scrollable,
+                textWidthBasis: widget.textWidthBasis,
+                enableInteractiveSelection: widget.enableSelectionInteraction,
+                autofocus: widget.autofocus,
+                spellCheckConfiguration: widget.spellCheckService != null
+                    ? SpellCheckConfiguration(
+                        spellCheckService: widget.spellCheckService,
+                      )
+                    : null,
+              ),
       ),
     );
   }

--- a/packages/fleather/test/widgets/editor_input_client_mixin_deltas_test.dart
+++ b/packages/fleather/test/widgets/editor_input_client_mixin_deltas_test.dart
@@ -27,6 +27,7 @@ class MockEditorState extends Mock implements EditorState {
       startHandleLayerLink: LayerLink(),
       endHandleLayerLink: LayerLink(),
       padding: EdgeInsets.zero,
+      textWidthBasis: TextWidthBasis.parent,
       cursorController: CursorController(
           showCursor: ValueNotifier(true),
           style: const CursorStyle(

--- a/packages/fleather/test/widgets/editor_test.dart
+++ b/packages/fleather/test/widgets/editor_test.dart
@@ -296,7 +296,7 @@ void main() {
       await editor.pumpAndTap();
       await editor.updateSelection(base: 0, extent: 3);
       await editor.disable();
-      final widget = tester.widget(find.byType(FleatherField)) as FleatherField;
+      final widget = tester.widget<FleatherField>(find.byType(FleatherField));
       expect(widget.readOnly, true);
     });
 
@@ -454,6 +454,48 @@ void main() {
           MaterialApp(home: FleatherEditor(controller: FleatherController()));
       await tester.pumpWidget(widget);
       // Fails if thrown
+    });
+
+    group('TextWidthBasis', () {
+      testWidgets('shrink editor to content size in read only', (tester) async {
+        final editor = EditorSandBox(
+          useField: false,
+          tester: tester,
+          document: ParchmentDocument.fromJson([
+            {'insert': 'a\n'}
+          ]),
+          autofocus: true,
+          // Scrollable forces expansion of editor
+          scrollable: false,
+          readOnly: true,
+          // We don't want to show cursor (will cause error if not scrollable)
+          showCursor: false,
+          textWidthBasis: TextWidthBasis.longestLine,
+        );
+        await editor.pump();
+        final state = tester.state<RawEditorState>(find.byType(RawEditor));
+        expect(state.renderEditor.size.width,
+            lessThan(MediaQuery.of(state.context).size.width / 2));
+      });
+
+      testWidgets(
+          'expands editor in edition mode, regardless of textWidthBasis',
+          (tester) async {
+        final editor = EditorSandBox(
+          useField: false,
+          tester: tester,
+          document: ParchmentDocument.fromJson([
+            {'insert': 'a\n'}
+          ]),
+          autofocus: true,
+          readOnly: false,
+          textWidthBasis: TextWidthBasis.longestLine,
+        );
+        await editor.pump();
+        final state = tester.state<RawEditorState>(find.byType(RawEditor));
+        expect(state.renderEditor.size.width,
+            MediaQuery.of(state.context).size.width);
+      });
     });
 
     testWidgets('Copy intent sends data to clipboard manager', (tester) async {


### PR DESCRIPTION
This PR allows editor to shrink to max content size in read-only

To acheive this, one can use a new paramter `textWidthBasis`
```dart
FleatherEditor(
   controller: controller,
   scrollable: false,
   readOnly: true,
   enableInteractiveSelection: false,
   textWidthBasis: TextWidthBasis.longestLine,
);
```

### How it renders

### Before
<img height="300" alt="image" src="https://github.com/user-attachments/assets/88d6f974-8417-4408-86e8-26a71af8e6a0" />

### After
<img  height="300" alt="image" src="https://github.com/user-attachments/assets/d7819a62-da26-431a-a0b7-fe2730c3691d" />
