### PR TITLE
TextWidthBasis value accounted for in `EditableTextBlock`

### DIFF
--- a/packages/fleather/lib/src/rendering/editable_text_block.dart
+++ b/packages/fleather/lib/src/rendering/editable_text_block.dart
@@ -14,14 +14,13 @@ class RenderEditableTextBlock extends RenderEditableContainerBox
     required super.textDirection,
     required EdgeInsetsGeometry padding,
     required Decoration decoration,
+    required super.textWidthBasis,
     EdgeInsets contentPadding = EdgeInsets.zero,
   })  : _decoration = decoration,
         _configuration = ImageConfiguration(textDirection: textDirection),
         _savedPadding = padding,
         _contentPadding = contentPadding,
-        super(
-          padding: padding.add(contentPadding),
-        );
+        super(padding: padding.add(contentPadding));
 
   EdgeInsetsGeometry _savedPadding;
   EdgeInsets _contentPadding;

--- a/packages/fleather/lib/src/rendering/editor.dart
+++ b/packages/fleather/lib/src/rendering/editor.dart
@@ -140,10 +140,10 @@ class RenderEditor extends RenderEditableContainerBox
     super.children,
     required super.padding,
     required super.textDirection,
+    required super.textWidthBasis,
     required ParchmentDocument document,
     required ViewportOffset offset,
     required bool hasFocus,
-    required TextWidthBasis textWidthBasis,
     required TextSelection selection,
     required LayerLink startHandleLayerLink,
     required LayerLink endHandleLayerLink,
@@ -160,7 +160,6 @@ class RenderEditor extends RenderEditableContainerBox
         _endHandleLayerLink = endHandleLayerLink,
         _cursorController = cursorController,
         _maxContentWidth = maxContentWidth,
-        _textWidthBasis = textWidthBasis,
         super(
           node: document.root,
         );
@@ -261,16 +260,6 @@ class RenderEditor extends RenderEditableContainerBox
   set maxContentWidth(double? value) {
     if (_maxContentWidth == value) return;
     _maxContentWidth = value;
-    markNeedsLayout();
-  }
-
-  TextWidthBasis _textWidthBasis;
-
-  TextWidthBasis get textWidthBasis => _textWidthBasis;
-
-  set textWidthBasis(TextWidthBasis value) {
-    if (_textWidthBasis == value) return;
-    _textWidthBasis = value;
     markNeedsLayout();
   }
 

--- a/packages/fleather/lib/src/widgets/editable_text_block.dart
+++ b/packages/fleather/lib/src/widgets/editable_text_block.dart
@@ -56,6 +56,7 @@ class EditableTextBlock extends StatelessWidget {
       node: node,
       padding: spacing,
       contentPadding: contentPadding,
+      textWidthBasis: textWidthBasis,
       decoration: _getDecorationForBlock(node, theme) ?? const BoxDecoration(),
       children: _buildChildren(context),
     );
@@ -273,10 +274,12 @@ class _EditableBlock extends MultiChildRenderObjectWidget {
   final VerticalSpacing padding;
   final Decoration decoration;
   final EdgeInsets? contentPadding;
+  final TextWidthBasis textWidthBasis;
 
   const _EditableBlock({
     required this.node,
     required this.decoration,
+    required this.textWidthBasis,
     required super.children,
     this.contentPadding,
     this.padding = const VerticalSpacing(),
@@ -295,6 +298,7 @@ class _EditableBlock extends MultiChildRenderObjectWidget {
       padding: _padding,
       decoration: decoration,
       contentPadding: _contentPadding,
+      textWidthBasis: textWidthBasis,
     );
   }
 
@@ -306,6 +310,7 @@ class _EditableBlock extends MultiChildRenderObjectWidget {
     renderObject.padding = _padding;
     renderObject.decoration = decoration;
     renderObject.contentPadding = _contentPadding;
+    renderObject.textWidthBasis = textWidthBasis;
   }
 }
 

--- a/packages/fleather/test/widgets/editor_test.dart
+++ b/packages/fleather/test/widgets/editor_test.dart
@@ -505,7 +505,12 @@ void main() {
           useField: false,
           tester: tester,
           document: ParchmentDocument.fromJson([
-            {'insert': 'a\n'}
+            {'insert': 'a'},
+            {'insert': 'list'},
+            {
+              'insert': '\n',
+              'attributes': {'block': 'ul'}
+            }
           ]),
           autofocus: true,
           // Scrollable forces expansion of editor


### PR DESCRIPTION
Fix editor not shrinking when document contain a block