### PR TITLE
Example image embed supports `num`

### DIFF
--- a/packages/fleather/example/lib/main.dart
+++ b/packages/fleather/example/lib/main.dart
@@ -180,8 +180,8 @@ class _HomePageState extends State<HomePage> {
           // Caret takes 2 pixels, hence not symmetric padding values.
           padding: const EdgeInsets.only(left: 4, right: 2, top: 2, bottom: 2),
           child: Container(
-            width: node.value.data['width'] ?? 300,
-            height: node.value.data['height'] ?? 300,
+            width: (node.value.data['width'] as num?)?.toDouble() ?? 300,
+            height: (node.value.data['height'] as num?)?.toDouble() ?? 300,
             decoration: BoxDecoration(
               image: DecorationImage(image: image, fit: BoxFit.cover),
             ),


### PR DESCRIPTION
This fixes an error in the example related to the input height & width of an image embed